### PR TITLE
feat(paste-guard): redact paste into ai tui tools via pty wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `secret-stripper redact` subcommand: read stdin, print the redacted text to stdout. Designed for shell pipelines and used internally by `paste-guard`.
+- `secret-stripper paste-guard -- <cmd>` subcommand: run a child process inside a PTY and rewrite any bracketed-paste payload sent on stdin, redacting secrets in flight. Targets AI terminal UIs like Claude Code, Codex CLI, aider, Gemini CLI, Continue, and opencode.
+- `init` walks `PATH` for a catalog of AI TUIs and prints a ready-to-copy shell alias snippet that routes each through `paste-guard`. Snippet is tailored to the detected shell (bash, zsh, fish) and names the exact rc file to paste into; on Windows or an unknown shell it falls back to generic instructions. The user copies it manually.
+
 ## [1.0.0] - 2026-05-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -1477,7 +1483,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -1542,13 +1548,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -1939,6 +1957,27 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2384,6 +2423,7 @@ dependencies = [
  "env_logger",
  "log",
  "notify-rust",
+ "portable-pty",
  "proptest",
  "ratatui",
  "regex",
@@ -2468,6 +2508,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2565,22 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2718,7 +2785,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -3671,6 +3738,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ semver = "1.0.28"
 tempfile = "3.27.0"
 sha2 = "0.11.0"
 chrono = { version = "0.4.44", default-features = false, features = ["std", "serde"] }
+portable-pty = "0.9.0"
 
 [dev-dependencies]
 proptest = "1.11.0"

--- a/README.md
+++ b/README.md
@@ -10,13 +10,7 @@
 
 ## Quick Start
 
-**Linux:**
-
-```bash
-curl -sSf https://secretstripper.download/install.sh | bash
-```
-
-**macOS:**
+**Linux / macOS:**
 
 ```bash
 curl -sSf https://secretstripper.download/install.sh | bash
@@ -43,6 +37,31 @@ cargo install --git https://github.com/kalix127/secret-stripper.git --locked && 
 Highlight text and press your default chord (Linux `Ctrl+Alt+X` / macOS `Cmd+Shift+C` / Windows `Ctrl+Alt+C`). The clipboard now holds a redacted version - paste with `Ctrl+V` (`Cmd+V` on macOS). On Linux the PRIMARY selection is read directly, so you can skip the `Ctrl+C`.
 
 Run `secret-stripper menu` to tune settings, or `secret-stripper --help` for all commands.
+
+---
+
+## Auto-redact paste into AI TUIs
+
+`secret-stripper init` looks for installed AI terminal tools (Claude Code, Codex CLI, aider, Gemini CLI, Continue, opencode) and prints a ready-to-copy shell alias block. Each alias routes the tool through `paste-guard`, a PTY wrapper that intercepts clipboard pastes and redacts secrets before they reach the AI's prompt - typing and normal output are untouched. Copy the snippet into your shell config (`~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish`, or your PowerShell profile) and open a new shell:
+
+```bash
+# ----------------------------------
+alias claude='secret-stripper paste-guard -- claude'
+alias codex='secret-stripper paste-guard -- codex'
+# ----------------------------------
+```
+
+Secret Stripper never writes to your shell rc on its own. To stop routing through `paste-guard`, delete the block between the dashed comment lines.
+
+**Scope.** `paste-guard` is a per-process wrapper - it only filters pastes into the *one* command you ran it on. Daily use of `ssh`, `psql`, `vim`, `kubectl`, the bare shell prompt, GUI apps, the system clipboard - all completely untouched. You can also add aliases for non-AI tools by hand (live demos against `psql` / `mysql`, screen-recordings) - wrapping leaf commands is fine, wrapping a whole shell usually is not.
+
+You can also pipe arbitrary text through the same engine:
+
+```bash
+cat secrets.log | secret-stripper redact > clean.log
+```
+
+**Limitations.** Bracketed paste must be supported by your terminal (every modern emulator does, including the VSCode integrated terminal and tmux passthrough); typed secrets are never modified, only pasted ones; paste payloads above 1 MiB fall through unredacted.
 
 ---
 

--- a/src/ai_tui/mod.rs
+++ b/src/ai_tui/mod.rs
@@ -1,0 +1,122 @@
+use std::env;
+use std::path::PathBuf;
+
+/// One AI TUI tool secret-stripper knows how to wrap with `paste-guard`.
+/// `binary` is the executable name to look up on PATH; `label` is the
+/// human-readable name shown in the init prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AiTui {
+    pub binary: &'static str,
+    pub label: &'static str,
+}
+
+/// Add a new entry here to teach `init` about another AI TUI. The matching
+/// binary name must be what users actually invoke from a shell prompt.
+pub const KNOWN: &[AiTui] = &[
+    AiTui {
+        binary: "claude",
+        label: "Claude Code",
+    },
+    AiTui {
+        binary: "codex",
+        label: "OpenAI Codex CLI",
+    },
+    AiTui {
+        binary: "aider",
+        label: "aider",
+    },
+    AiTui {
+        binary: "gemini",
+        label: "Google Gemini CLI",
+    },
+    AiTui {
+        binary: "continue",
+        label: "Continue CLI",
+    },
+    AiTui {
+        binary: "opencode",
+        label: "opencode",
+    },
+];
+
+/// Return the subset of `KNOWN` whose binary is reachable on the current
+/// process's PATH. Order matches `KNOWN`.
+pub fn detect() -> Vec<AiTui> {
+    KNOWN
+        .iter()
+        .filter(|t| which_on_path(t.binary).is_some())
+        .copied()
+        .collect()
+}
+
+/// Minimal `which` reimplementation - we already shell out for OS integration
+/// but adding a `which` crate just to walk PATH is not worth it.
+fn which_on_path(name: &str) -> Option<PathBuf> {
+    let path = env::var_os("PATH")?;
+    for dir in env::split_paths(&path) {
+        let candidate = dir.join(name);
+        if is_executable(&candidate) {
+            return Some(candidate);
+        }
+        #[cfg(target_os = "windows")]
+        {
+            for ext in ["exe", "cmd", "bat", "ps1"] {
+                let mut p = candidate.clone();
+                p.set_extension(ext);
+                if p.is_file() {
+                    return Some(p);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    match path.metadata() {
+        Ok(m) => m.is_file() && (m.permissions().mode() & 0o111 != 0),
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &std::path::Path) -> bool {
+    path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_catalog_has_unique_binaries() {
+        let mut bins: Vec<&str> = KNOWN.iter().map(|t| t.binary).collect();
+        let n = bins.len();
+        bins.sort();
+        bins.dedup();
+        assert_eq!(bins.len(), n, "duplicate binary in KNOWN catalog");
+    }
+
+    #[test]
+    fn detect_finds_stub_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin_path = dir.path().join("claude");
+        std::fs::write(&bin_path, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&bin_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&bin_path, perms).unwrap();
+        }
+        let saved = env::var_os("PATH");
+        env::set_var("PATH", dir.path());
+        let found = detect();
+        if let Some(p) = saved {
+            env::set_var("PATH", p);
+        }
+        assert!(found.iter().any(|t| t.binary == "claude"));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,19 @@ pub enum Command {
         #[arg(long)]
         auto_install: bool,
     },
+    /// Read text from stdin, redact secrets/PII using the active config, write
+    /// the result to stdout. Designed for shell pipelines and as the engine
+    /// behind the `paste-guard` wrapper.
+    Redact,
+    /// Run a child program inside a PTY and redact any bracketed-paste
+    /// payloads on the way in. Exits with the child's exit code. Use it to
+    /// wrap AI TUIs like Claude Code or Codex so pasted secrets never reach
+    /// the prompt.
+    PasteGuard {
+        /// The child command and its arguments. Pass after `--`.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
+        argv: Vec<String>,
+    },
     /// Benchmark redact-trigger latency across the three detection presets.
     /// Hidden from --help; intended for maintainers comparing release builds.
     #[command(hide = true)]

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -1532,6 +1532,55 @@ lang_strings! {
         IT => "Cambia la lingua dell'interfaccia",
         ES => "Cambia el idioma de la interfaz",
     }
+
+    ai_tui_detected_title {
+        EN => "Detected AI TUIs on this system:",
+        FR => "Outils TUI d'IA détectés sur ce système :",
+        IT => "TUI di IA rilevate su questo sistema:",
+        ES => "TUI de IA detectadas en este sistema:",
+    }
+    ai_tui_why {
+        EN => "Add the snippet below to your shell config so each tool runs through 'paste-guard'. The wrapper sits between your terminal and the AI TUI, intercepting clipboard pastes and redacting any secrets or PII before they reach the prompt. Typing and normal output stay untouched.",
+        FR => "Ajoutez le bloc ci-dessous à la configuration de votre shell pour que chaque outil passe par 'paste-guard'. Ce wrapper se place entre votre terminal et l'outil d'IA, intercepte les collages du presse-papiers et masque les secrets ou les données personnelles avant qu'ils n'atteignent l'invite. La frappe et la sortie normale ne sont pas modifiées.",
+        IT => "Aggiungi il blocco qui sotto alla configurazione della shell così ogni strumento passa attraverso 'paste-guard'. Il wrapper si frappone tra il terminale e la TUI di IA, intercetta gli incolla dagli appunti e oscura segreti o dati personali prima che raggiungano il prompt. La digitazione e l'output normale restano invariati.",
+        ES => "Añade el bloque siguiente a la configuración de tu shell para que cada herramienta pase por 'paste-guard'. El envoltorio se sitúa entre tu terminal y la TUI de IA, intercepta los pegados del portapapeles y redacta los secretos o datos personales antes de que lleguen al prompt. La escritura y la salida normal no se ven afectadas.",
+    }
+    ai_tui_add_to_file(path: &str,) {
+        EN => format!("Add the lines below to {} (then open a new shell or run 'source {}'):", path, path),
+        FR => format!("Ajoutez les lignes ci-dessous à {} (puis ouvrez un nouveau shell ou exécutez 'source {}') :", path, path),
+        IT => format!("Aggiungi le righe sottostanti a {} (poi apri una nuova shell o esegui 'source {}'):", path, path),
+        ES => format!("Añade las líneas siguientes a {} (después abre un nuevo shell o ejecuta 'source {}'):", path, path),
+    }
+    ai_tui_add_to_unknown_shell {
+        EN => "Could not detect your shell from $SHELL. Add the lines below to your shell's startup file (e.g. ~/.bashrc, ~/.zshrc, ~/.config/fish/config.fish, or the PowerShell profile on Windows):",
+        FR => "Impossible de détecter votre shell via $SHELL. Ajoutez les lignes ci-dessous au fichier de démarrage de votre shell (par ex. ~/.bashrc, ~/.zshrc, ~/.config/fish/config.fish, ou le profil PowerShell sous Windows) :",
+        IT => "Impossibile rilevare la shell da $SHELL. Aggiungi le righe sottostanti al file di avvio della tua shell (ad es. ~/.bashrc, ~/.zshrc, ~/.config/fish/config.fish, oppure il profilo PowerShell su Windows):",
+        ES => "No se pudo detectar tu shell desde $SHELL. Añade las líneas siguientes al archivo de inicio de tu shell (por ejemplo ~/.bashrc, ~/.zshrc, ~/.config/fish/config.fish, o el perfil de PowerShell en Windows):",
+    }
+    ai_tui_none_detected {
+        EN => "No supported AI TUIs detected on PATH. If you install one later, re-run 'secret-stripper init' to see the alias snippet.",
+        FR => "Aucun outil TUI d'IA pris en charge détecté dans le PATH. Si vous en installez un plus tard, relancez 'secret-stripper init' pour obtenir le bloc d'alias.",
+        IT => "Nessuna TUI di IA supportata rilevata nel PATH. Se ne installi una in seguito, rilancia 'secret-stripper init' per vedere lo snippet di alias.",
+        ES => "No se detectó ninguna TUI de IA compatible en el PATH. Si instalas una más adelante, vuelve a ejecutar 'secret-stripper init' para ver el bloque de alias.",
+    }
+    ai_tui_remove_hint {
+        EN => "To stop routing through paste-guard, delete the block above (between the dashed comment lines) from your shell config, or run 'secret-stripper uninstall' to clean up everything at once.",
+        FR => "Pour cesser d'utiliser paste-guard, supprimez le bloc ci-dessus (entre les lignes de commentaire en tirets) de la configuration de votre shell, ou exécutez 'secret-stripper uninstall' pour tout nettoyer en une fois.",
+        IT => "Per non far più passare il pasting da paste-guard, elimina il blocco qui sopra (tra le righe di commento tratteggiate) dalla configurazione della tua shell, oppure esegui 'secret-stripper uninstall' per ripulire tutto in una volta.",
+        ES => "Para dejar de pasar por paste-guard, elimina el bloque de arriba (entre las líneas de comentario con guiones) de la configuración de tu shell, o ejecuta 'secret-stripper uninstall' para limpiar todo de una vez.",
+    }
+    ai_tui_alias_removed(path: &str,) {
+        EN => format!("Removed paste-guard alias block from {}", path),
+        FR => format!("Bloc d'alias paste-guard supprimé de {}", path),
+        IT => format!("Blocco di alias paste-guard rimosso da {}", path),
+        ES => format!("Bloque de alias paste-guard eliminado de {}", path),
+    }
+    pg_no_child {
+        EN => "paste-guard: no child command provided. Usage: secret-stripper paste-guard -- <cmd> [args...]",
+        FR => "paste-guard : aucune commande enfant fournie. Usage : secret-stripper paste-guard -- <cmd> [args...]",
+        IT => "paste-guard: nessun comando figlio fornito. Uso: secret-stripper paste-guard -- <cmd> [args...]",
+        ES => "paste-guard: no se proporcionó ningún comando hijo. Uso: secret-stripper paste-guard -- <cmd> [args...]",
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
+pub mod ai_tui;
 pub mod config;
 pub mod detector;
 pub mod lang;
+pub mod redact_cli;
+pub mod shell_rc;
 pub mod stats;
 
 pub use detector::deep_scan::DeepFinding;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,13 @@ mod cli;
 mod clipboard;
 mod hotkey;
 mod notify;
+mod paste_guard;
 mod proc;
 mod shortcut;
 mod tui;
 mod updater;
 
-pub use secret_stripper::{config, detector, lang, stats};
+pub use secret_stripper::{ai_tui, config, detector, lang, redact_cli, shell_rc, stats};
 
 /// Product name. Single source so window/notification/shortcut labels stay
 /// consistent; deliberately not localized (it is a proper noun).
@@ -32,6 +33,12 @@ fn main() -> anyhow::Result<()> {
         cli::Command::Uninstall => run_uninstall()?,
         cli::Command::Upgrade => updater::run_upgrade()?,
         cli::Command::UpgradeCheck { auto_install } => updater::run_upgrade_check(auto_install)?,
+        cli::Command::Redact => redact_cli::run_redact()?,
+        cli::Command::PasteGuard { argv } => {
+            let cfg = Config::load();
+            let code = paste_guard::run(&argv, &cfg)?;
+            std::process::exit(code);
+        }
         cli::Command::Bench { iterations } => run_bench(iterations)?,
     }
 
@@ -98,6 +105,17 @@ fn run_uninstall() -> anyhow::Result<()> {
     let lang = lang::Lang::active();
     let _ = shortcut::unregister();
     let _ = updater::uninstall_update_check_timer();
+
+    // Trim our managed alias block from the user's shell rc. Best effort:
+    // unknown shell, missing rc, or unreadable rc just skips silently.
+    // Honors SECRET_STRIPPER_NO_OS_SIDE_EFFECTS via shell_rc::uninstall_aliases.
+    if let Some(shell) = shell_rc::Shell::from_env() {
+        if let Some(rc) = shell.rc_path() {
+            if let Ok(true) = shell_rc::uninstall_aliases(&rc) {
+                println!("{}", lang.ai_tui_alias_removed(&rc.display().to_string()));
+            }
+        }
+    }
 
     let removed = config::purge_config_dir();
 
@@ -385,8 +403,52 @@ fn run_init() -> anyhow::Result<()> {
             eprintln!("{}", lang.cli_last_error(&err.to_string()));
         }
     }
+    // Print the general settings hint here, before the paste-guard section,
+    // so the "tweak settings" line clearly applies to the defaults above
+    // (sensitivity, redact pattern, notifications, etc.) and not to the
+    // paste-guard alias snippet that follows.
     println!("{}", lang.cli_tweak_later());
+    print_paste_guard_hint(lang);
     Ok(())
+}
+
+/// Show the user the alias snippet for paste-guard, explain why, and tell
+/// them which file to paste it into. We never edit the file ourselves -
+/// shell rc files belong to the user.
+fn print_paste_guard_hint(lang: lang::Lang) {
+    let detected = ai_tui::detect();
+    if detected.is_empty() {
+        println!();
+        println!("{}", lang.ai_tui_none_detected());
+        return;
+    }
+
+    let shell = shell_rc::Shell::from_env();
+    let bins: Vec<&str> = detected.iter().map(|t| t.binary).collect();
+
+    println!();
+    println!("{}", lang.ai_tui_detected_title());
+    for t in &detected {
+        println!("  - {} ({})", t.label, t.binary);
+    }
+    println!();
+    println!("{}", lang.ai_tui_why());
+    println!();
+
+    let snippet_shell = shell.unwrap_or(shell_rc::Shell::Bash);
+    match shell.and_then(|s| s.rc_path().map(|p| (s, p))) {
+        Some((_, path)) => {
+            let path_str = path.display().to_string();
+            println!("{}", lang.ai_tui_add_to_file(&path_str));
+        }
+        None => {
+            println!("{}", lang.ai_tui_add_to_unknown_shell());
+        }
+    }
+    println!();
+    print!("{}", shell_rc::render_alias_snippet(snippet_shell, &bins));
+    println!();
+    println!("{}", lang.ai_tui_remove_hint());
 }
 
 fn run_bench(iterations: usize) -> anyhow::Result<()> {

--- a/src/paste_guard/mod.rs
+++ b/src/paste_guard/mod.rs
@@ -1,0 +1,201 @@
+use std::io::{Read, Write};
+use std::sync::Arc;
+use std::thread;
+
+use anyhow::Context;
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+
+use crate::config::Config;
+use crate::detector::Detector;
+use crate::redact_cli::redact_with;
+
+mod parser;
+pub use parser::PasteParser;
+
+/// Limit on a single paste payload before we give up on in-flight redaction.
+/// Above this the parser falls back to passthrough so we never OOM on a
+/// pathological paste. 1 MiB matches the cap in `run_trigger`.
+pub const MAX_PASTE_BYTES: usize = 1024 * 1024;
+
+pub const START_SEQ: &[u8] = b"\x1b[200~";
+pub const END_SEQ: &[u8] = b"\x1b[201~";
+
+const ENV_NO_OS: &str = "SECRET_STRIPPER_NO_OS_SIDE_EFFECTS";
+
+/// Spawn `argv` in a PTY, intercept bracketed-paste payloads on the way in,
+/// redact them, and forward. Returns the child's exit code.
+///
+/// Long-lived for the lifetime of the child - this is the second carve-out
+/// from the one-shot model documented in CLAUDE.md (the first is the daily
+/// update-check scheduler). Holds no global state, no PID file.
+pub fn run(argv: &[String], cfg: &Config) -> anyhow::Result<i32> {
+    if argv.is_empty() {
+        let lang = cfg.lang;
+        eprintln!("{}", lang.pg_no_child());
+        return Ok(2);
+    }
+    // Allow tests / scripts to verify wiring without touching the real PTY.
+    if std::env::var_os(ENV_NO_OS).is_some() {
+        return Ok(0);
+    }
+
+    let detector = Arc::new(Detector::from_config(cfg));
+    let cfg = Arc::new(cfg.clone());
+
+    let pty_system = native_pty_system();
+    let (rows, cols) = terminal_size().unwrap_or((24, 80));
+    let pair = pty_system
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .context("openpty failed")?;
+
+    let mut cmd = CommandBuilder::new(&argv[0]);
+    for a in &argv[1..] {
+        cmd.arg(a);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        cmd.cwd(cwd);
+    }
+
+    let mut child = pair
+        .slave
+        .spawn_command(cmd)
+        .with_context(|| format!("failed to spawn '{}'", argv[0]))?;
+    drop(pair.slave);
+
+    // RAII: raw mode + force bracketed-paste on the parent terminal for the
+    // duration of the wrapped session. Forcing the mode on means the wrapper
+    // works for ANY child, not just AI TUIs that enable bracketed paste
+    // themselves (vim, claude, codex). Children that re-enable it
+    // independently are unaffected - the request is idempotent. Restored
+    // on Drop so the user's shell prompt comes back the way they left it.
+    let _guard = TerminalGuard::enter();
+
+    let mut pty_reader = pair.master.try_clone_reader().context("clone reader")?;
+    let mut pty_writer = pair.master.take_writer().context("take_writer (master)")?;
+    // Drop the master itself; the cloned reader and the moved writer keep
+    // their own references. Holding `master` here would keep an extra handle
+    // alive after the input pump finishes and stop the child from ever
+    // seeing EOF on its stdin.
+    drop(pair.master);
+
+    // Child -> stdout pump.
+    let stdout_pump = thread::spawn(move || {
+        let mut buf = [0u8; 8192];
+        let stdout = std::io::stdout();
+        loop {
+            match pty_reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let mut out = stdout.lock();
+                    if out.write_all(&buf[..n]).is_err() {
+                        break;
+                    }
+                    let _ = out.flush();
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    // Stdin -> child pump (paste parser). Owns the PTY master writer so it
+    // is dropped on stdin EOF, which closes the master and signals EOF to
+    // the child. If we kept a clone in the main thread, `child.wait()`
+    // would deadlock against a child that exits only on stdin close (cat,
+    // grep, etc.).
+    //
+    // Feedback policy: never write to the parent's stderr while the wrapped
+    // child is rendering a TUI - it punches through the frame (see
+    // CLAUDE.md::tui-no-stdout). Instead, fire a desktop notification per
+    // redaction event (gated on `!config.silent` to match the trigger
+    // flow). The visible proof is the AI TUI rendering `[REDACTED]` in
+    // place of the secret in its own input field.
+    let detector_for_parser = Arc::clone(&detector);
+    let cfg_for_parser = Arc::clone(&cfg);
+    let stdin_pump = thread::spawn(move || {
+        let mut parser = PasteParser::new();
+        let mut buf = [0u8; 8192];
+        let stdin = std::io::stdin();
+        loop {
+            let n = match stdin.lock().read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(_) => break,
+            };
+            let mut redacted_total: usize = 0;
+            let mut redactor = |payload: &[u8]| match std::str::from_utf8(payload) {
+                Ok(s) => {
+                    let (red, names) = redact_with(&detector_for_parser, &cfg_for_parser, s);
+                    redacted_total += names.len();
+                    red.into_bytes()
+                }
+                Err(_) => payload.to_vec(),
+            };
+            let out_bytes = parser.feed(&buf[..n], &mut redactor);
+            // Overflow is rare and unactionable mid-session; drop it on the
+            // floor rather than corrupt the TUI frame. The fact that the
+            // paste was not redacted is observable in the child itself.
+            let _ = parser.take_overflow();
+            if redacted_total > 0 && !cfg_for_parser.silent {
+                crate::notify::redacted_notification(
+                    redacted_total,
+                    cfg_for_parser.notification_timeout_secs,
+                    cfg_for_parser.lang,
+                );
+            }
+            if !out_bytes.is_empty() && pty_writer.write_all(&out_bytes).is_err() {
+                break;
+            }
+            let _ = pty_writer.flush();
+        }
+        // Explicit drop: makes the EOF -> child semantics easy to spot.
+        drop(pty_writer);
+    });
+
+    let status = child.wait().context("child wait")?;
+    let _ = stdout_pump.join();
+    // The stdin pump may still be parked in a blocking stdin read when an
+    // interactive child exits on its own; the process exit at the call site
+    // tears that thread down.
+    let _ = stdin_pump;
+    let code = status.exit_code() as i32;
+    drop(_guard);
+    Ok(code)
+}
+
+fn terminal_size() -> Option<(u16, u16)> {
+    crossterm::terminal::size().ok().map(|(c, r)| (r, c))
+}
+
+struct TerminalGuard;
+
+const ENABLE_BRACKETED_PASTE: &[u8] = b"\x1b[?2004h";
+const DISABLE_BRACKETED_PASTE: &[u8] = b"\x1b[?2004l";
+
+impl TerminalGuard {
+    fn enter() -> Self {
+        let _ = crossterm::terminal::enable_raw_mode();
+        // Force bracketed-paste mode on the parent terminal so the wrapper
+        // sees framed pastes regardless of whether the child requests them.
+        // Best effort: a terminal that doesn't understand the sequence will
+        // silently ignore it, which is the same as the wrapper not being
+        // there.
+        let mut out = std::io::stdout();
+        let _ = out.write_all(ENABLE_BRACKETED_PASTE);
+        let _ = out.flush();
+        Self
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let mut out = std::io::stdout();
+        let _ = out.write_all(DISABLE_BRACKETED_PASTE);
+        let _ = out.flush();
+        let _ = crossterm::terminal::disable_raw_mode();
+    }
+}

--- a/src/paste_guard/parser.rs
+++ b/src/paste_guard/parser.rs
@@ -1,0 +1,282 @@
+use super::{END_SEQ, MAX_PASTE_BYTES, START_SEQ};
+
+/// Streaming parser that extracts bracketed-paste payloads from a byte
+/// stream, runs each through a user-supplied redactor, and reframes the
+/// result. Everything outside a paste passes through byte-for-byte.
+///
+/// Operates on arbitrarily-chunked input: partial matches at chunk
+/// boundaries are remembered across `feed()` calls.
+#[derive(Debug)]
+pub struct PasteParser {
+    state: State,
+    // Passthrough: how many bytes of START_SEQ are matched.
+    start_match: usize,
+    // InPaste: accumulator + how many bytes of END_SEQ are matched in tail.
+    paste_buffer: Vec<u8>,
+    end_match: usize,
+    // Sticky flag: set when the buffer cap fires during the current or any
+    // prior `feed` call. Cleared by `take_overflow()`. Lets the caller emit
+    // the localized stderr notice exactly once per overflow event.
+    overflowed: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum State {
+    /// Outside any paste. Watching for `\e[200~`.
+    Passthrough,
+    /// Inside a paste, buffering for redaction. Watching for `\e[201~`.
+    InPaste,
+    /// Inside a paste that exceeded the buffer cap. Forward bytes as-is and
+    /// just watch for the end marker so we don't permanently desync.
+    InPasteBypass,
+}
+
+impl Default for PasteParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PasteParser {
+    pub fn new() -> Self {
+        Self {
+            state: State::Passthrough,
+            start_match: 0,
+            paste_buffer: Vec::new(),
+            end_match: 0,
+            overflowed: false,
+        }
+    }
+
+    /// True if a paste hit the buffer cap since the last call. Resets the
+    /// internal flag so the caller emits the notice at most once per event.
+    pub fn take_overflow(&mut self) -> bool {
+        std::mem::replace(&mut self.overflowed, false)
+    }
+
+    /// Feed a chunk of input. `redact` is called once per completed paste
+    /// with the paste payload (without the surrounding sequences); it must
+    /// return the redacted payload to splice back in. Returns the bytes to
+    /// forward to the child PTY.
+    pub fn feed<F>(&mut self, input: &[u8], redact: &mut F) -> Vec<u8>
+    where
+        F: FnMut(&[u8]) -> Vec<u8>,
+    {
+        let mut out = Vec::with_capacity(input.len());
+        for &b in input {
+            match self.state {
+                State::Passthrough => self.feed_passthrough(b, &mut out),
+                State::InPaste => self.feed_in_paste(b, &mut out, redact),
+                State::InPasteBypass => self.feed_bypass(b, &mut out),
+            }
+        }
+        out
+    }
+
+    fn feed_passthrough(&mut self, b: u8, out: &mut Vec<u8>) {
+        if b == START_SEQ[self.start_match] {
+            self.start_match += 1;
+            if self.start_match == START_SEQ.len() {
+                self.state = State::InPaste;
+                self.paste_buffer.clear();
+                self.end_match = 0;
+                self.start_match = 0;
+            }
+            return;
+        }
+        // Mismatch: flush whatever prefix we'd buffered, then re-evaluate b.
+        if self.start_match > 0 {
+            out.extend_from_slice(&START_SEQ[..self.start_match]);
+            self.start_match = 0;
+        }
+        if b == START_SEQ[0] {
+            self.start_match = 1;
+        } else {
+            out.push(b);
+        }
+    }
+
+    fn feed_in_paste<F>(&mut self, b: u8, out: &mut Vec<u8>, redact: &mut F)
+    where
+        F: FnMut(&[u8]) -> Vec<u8>,
+    {
+        self.paste_buffer.push(b);
+        // Track end-marker match in tail of paste_buffer.
+        if b == END_SEQ[self.end_match] {
+            self.end_match += 1;
+            if self.end_match == END_SEQ.len() {
+                // Strip the end marker bytes (last 6) from the payload.
+                let cut = self.paste_buffer.len() - END_SEQ.len();
+                let payload = self.paste_buffer[..cut].to_vec();
+                let redacted = redact(&payload);
+                out.extend_from_slice(START_SEQ);
+                out.extend_from_slice(&redacted);
+                out.extend_from_slice(END_SEQ);
+                self.paste_buffer.clear();
+                self.end_match = 0;
+                self.state = State::Passthrough;
+                return;
+            }
+        } else {
+            // Partial-match restart for the end marker.
+            self.end_match = if b == END_SEQ[0] { 1 } else { 0 };
+        }
+        if self.paste_buffer.len() > MAX_PASTE_BYTES {
+            // Fail open: emit the original start marker plus everything we
+            // buffered so far and switch to bypass so subsequent bytes (and
+            // the eventual end marker) just stream through unchanged. The
+            // caller observes the event via `take_overflow()`.
+            out.extend_from_slice(START_SEQ);
+            out.extend_from_slice(&self.paste_buffer);
+            self.paste_buffer.clear();
+            self.end_match = 0;
+            self.state = State::InPasteBypass;
+            self.overflowed = true;
+        }
+    }
+
+    fn feed_bypass(&mut self, b: u8, out: &mut Vec<u8>) {
+        out.push(b);
+        if b == END_SEQ[self.end_match] {
+            self.end_match += 1;
+            if self.end_match == END_SEQ.len() {
+                self.end_match = 0;
+                self.state = State::Passthrough;
+            }
+        } else {
+            self.end_match = if b == END_SEQ[0] { 1 } else { 0 };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity_redact(payload: &[u8]) -> Vec<u8> {
+        payload.to_vec()
+    }
+
+    fn upper_redact(payload: &[u8]) -> Vec<u8> {
+        payload.iter().map(|b| b.to_ascii_uppercase()).collect()
+    }
+
+    #[test]
+    fn passthrough_keeps_normal_bytes() {
+        let mut p = PasteParser::new();
+        let out = p.feed(b"hello world\n", &mut identity_redact);
+        assert_eq!(out, b"hello world\n");
+    }
+
+    #[test]
+    fn paste_is_redacted_in_place() {
+        let mut p = PasteParser::new();
+        let mut input = Vec::new();
+        input.extend_from_slice(b"prefix ");
+        input.extend_from_slice(START_SEQ);
+        input.extend_from_slice(b"hello");
+        input.extend_from_slice(END_SEQ);
+        input.extend_from_slice(b" suffix");
+
+        let out = p.feed(&input, &mut upper_redact);
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"prefix ");
+        expected.extend_from_slice(START_SEQ);
+        expected.extend_from_slice(b"HELLO");
+        expected.extend_from_slice(END_SEQ);
+        expected.extend_from_slice(b" suffix");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn paste_split_across_chunks() {
+        let mut p = PasteParser::new();
+        let mut all = Vec::new();
+        // Chunk 1: partial start marker
+        all.extend(p.feed(b"\x1b[", &mut upper_redact));
+        // Chunk 2: rest of start marker + first half of payload
+        all.extend(p.feed(b"200~hel", &mut upper_redact));
+        // Chunk 3: second half + partial end marker
+        all.extend(p.feed(b"lo\x1b[20", &mut upper_redact));
+        // Chunk 4: rest of end marker + trailing text
+        all.extend(p.feed(b"1~done", &mut upper_redact));
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(START_SEQ);
+        expected.extend_from_slice(b"HELLO");
+        expected.extend_from_slice(END_SEQ);
+        expected.extend_from_slice(b"done");
+        assert_eq!(all, expected);
+    }
+
+    #[test]
+    fn escape_that_is_not_paste_start_passes_through() {
+        let mut p = PasteParser::new();
+        // ESC [ 1 ; 5 D - some cursor key sequence, must pass through.
+        let out = p.feed(b"\x1b[1;5D", &mut identity_redact);
+        assert_eq!(out, b"\x1b[1;5D");
+    }
+
+    #[test]
+    fn partial_start_followed_by_new_escape() {
+        let mut p = PasteParser::new();
+        // ESC [ 2 then a stray byte that breaks the start sequence: should
+        // flush "ESC [ 2" and then re-evaluate the stray byte. Final stream
+        // should equal the input unchanged.
+        let out = p.feed(b"\x1b[2X", &mut identity_redact);
+        assert_eq!(out, b"\x1b[2X");
+    }
+
+    #[test]
+    fn empty_paste() {
+        let mut p = PasteParser::new();
+        let mut input = Vec::new();
+        input.extend_from_slice(START_SEQ);
+        input.extend_from_slice(END_SEQ);
+        let out = p.feed(&input, &mut upper_redact);
+        // redactor called with empty payload -> empty output
+        let mut expected = Vec::new();
+        expected.extend_from_slice(START_SEQ);
+        expected.extend_from_slice(END_SEQ);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn overflow_sets_take_overflow_flag_once() {
+        let mut p = PasteParser::new();
+        let mut input = Vec::new();
+        input.extend_from_slice(START_SEQ);
+        // Paste payload bigger than the cap.
+        input.resize(input.len() + MAX_PASTE_BYTES + 16, b'A');
+        input.extend_from_slice(END_SEQ);
+
+        let _ = p.feed(&input, &mut identity_redact);
+        assert!(p.take_overflow(), "overflow flag should be set");
+        assert!(
+            !p.take_overflow(),
+            "second take_overflow should be false (one-shot)"
+        );
+    }
+
+    #[test]
+    fn back_to_back_pastes() {
+        let mut p = PasteParser::new();
+        let mut input = Vec::new();
+        input.extend_from_slice(START_SEQ);
+        input.extend_from_slice(b"one");
+        input.extend_from_slice(END_SEQ);
+        input.extend_from_slice(START_SEQ);
+        input.extend_from_slice(b"two");
+        input.extend_from_slice(END_SEQ);
+        let out = p.feed(&input, &mut upper_redact);
+        let mut expected = Vec::new();
+        expected.extend_from_slice(START_SEQ);
+        expected.extend_from_slice(b"ONE");
+        expected.extend_from_slice(END_SEQ);
+        expected.extend_from_slice(START_SEQ);
+        expected.extend_from_slice(b"TWO");
+        expected.extend_from_slice(END_SEQ);
+        assert_eq!(out, expected);
+    }
+}

--- a/src/redact_cli.rs
+++ b/src/redact_cli.rs
@@ -1,0 +1,74 @@
+use std::io::{self, Read, Write};
+
+use crate::config::Config;
+use crate::detector::{self, Detector};
+
+/// One-shot redaction pass over a string. Shared between the `redact`
+/// subcommand (stdin -> stdout) and the `paste-guard` wrapper (per-paste
+/// payload). Returns the redacted text and the list of pattern names that
+/// matched, in matched order, deduplicated.
+pub fn redact_with(detector: &Detector, cfg: &Config, text: &str) -> (String, Vec<String>) {
+    let result = detector.scan(text);
+    if !result.has_secrets {
+        return (text.to_string(), Vec::new());
+    }
+
+    let entropy_tokens: Vec<&str> = result
+        .high_entropy_tokens
+        .iter()
+        .map(|(t, _)| t.as_str())
+        .collect();
+    let mut deep_spans: Vec<(usize, usize)> =
+        result.deep_findings.iter().filter_map(|f| f.span).collect();
+    deep_spans.extend(result.extra_spans.iter().copied());
+
+    let redacted = detector::redact::redact_with_spans(
+        text,
+        &result.matched_spans,
+        &entropy_tokens,
+        &deep_spans,
+        detector.allowlist(),
+        &cfg.redact_pattern,
+    );
+
+    let mut names: Vec<String> = Vec::new();
+    for (name, _category, _sev) in &result.matched_patterns {
+        if !names.iter().any(|n| n.as_str() == *name) {
+            names.push((*name).to_string());
+        }
+    }
+    for f in &result.deep_findings {
+        if !names.iter().any(|x| x == f.finding_type) {
+            names.push(f.finding_type.to_string());
+        }
+    }
+    if !result.high_entropy_tokens.is_empty() && !names.iter().any(|n| n == "entropy") {
+        names.push("entropy".to_string());
+    }
+
+    // Fallback: deep-scan caught it but the redactor produced an identical
+    // string (no span info). Replace the whole input with the configured
+    // marker so the secret cannot survive the round-trip. Mirrors the
+    // trigger flow in main.rs::run_trigger.
+    let final_text = if redacted == text {
+        cfg.redact_pattern.clone()
+    } else {
+        redacted
+    };
+
+    (final_text, names)
+}
+
+pub fn run_redact() -> anyhow::Result<()> {
+    let cfg = Config::load();
+    let detector = Detector::from_config(&cfg);
+
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+
+    let (redacted, _names) = redact_with(&detector, &cfg, &input);
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    out.write_all(redacted.as_bytes())?;
+    Ok(())
+}

--- a/src/shell_rc/mod.rs
+++ b/src/shell_rc/mod.rs
@@ -1,0 +1,288 @@
+use std::path::{Path, PathBuf};
+
+use crate::config::atomic_write;
+
+pub const BLOCK_BEGIN: &str = "# ---- secret-stripper paste-guard ----";
+pub const BLOCK_END: &str = "# ---- secret-stripper paste-guard ----";
+
+/// Substring that uniquely identifies a paste-guard alias line in the user's
+/// rc file. `uninstall` falls back to this when the fence comments have
+/// been stripped or edited.
+pub const ALIAS_MARKER: &str = "secret-stripper paste-guard --";
+
+const ENV_NO_OS: &str = "SECRET_STRIPPER_NO_OS_SIDE_EFFECTS";
+
+fn os_side_effects_allowed() -> bool {
+    std::env::var_os(ENV_NO_OS).is_none()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+impl Shell {
+    /// Pick the shell from `$SHELL`. `None` on Windows, an unknown shell, or
+    /// when the variable is missing - the caller falls back to printing
+    /// generic instructions in those cases.
+    pub fn from_env() -> Option<Self> {
+        let raw = std::env::var("SHELL").ok()?;
+        let name = Path::new(&raw).file_name()?.to_string_lossy().to_string();
+        match name.as_str() {
+            "bash" => Some(Shell::Bash),
+            "zsh" => Some(Shell::Zsh),
+            "fish" => Some(Shell::Fish),
+            _ => None,
+        }
+    }
+
+    pub fn rc_path(&self) -> Option<PathBuf> {
+        let home = dirs::home_dir()?;
+        Some(match self {
+            Shell::Bash => home.join(".bashrc"),
+            Shell::Zsh => home.join(".zshrc"),
+            Shell::Fish => home.join(".config/fish/config.fish"),
+        })
+    }
+
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Shell::Bash => "bash",
+            Shell::Zsh => "zsh",
+            Shell::Fish => "fish",
+        }
+    }
+
+    /// Fish uses `alias name 'target'` instead of POSIX `alias name='target'`.
+    fn alias_line(&self, name: &str, target: &str) -> String {
+        match self {
+            Shell::Fish => format!("alias {} '{}'", name, target),
+            _ => format!("alias {}='{}'", name, target),
+        }
+    }
+}
+
+/// Render the alias snippet a user would paste into their shell rc. Each
+/// alias routes one detected AI TUI through `paste-guard`. Fenced with
+/// sentinel comments so the user (or a future script) can find / remove the
+/// block later.
+pub fn render_alias_snippet(shell: Shell, binaries: &[&str]) -> String {
+    let mut out = String::new();
+    out.push_str(BLOCK_BEGIN);
+    out.push('\n');
+    for b in binaries {
+        let target = format!("secret-stripper paste-guard -- {}", b);
+        out.push_str(&shell.alias_line(b, &target));
+        out.push('\n');
+    }
+    out.push_str(BLOCK_END);
+    out.push('\n');
+    out
+}
+
+/// Remove a previously-pasted paste-guard alias block from `rc_path`.
+///
+/// Returns `Ok(true)` if a block was found and removed, `Ok(false)` if no
+/// block was present (file missing, empty, or no paste-guard markers).
+/// Atomic write via tempfile + rename so a torn rc is impossible.
+///
+/// Honors `SECRET_STRIPPER_NO_OS_SIDE_EFFECTS`: returns `Ok(false)` without
+/// touching the file when set, so tests can exercise `run_uninstall`
+/// without writing to the developer's real shell rc.
+///
+/// Detection strategy, in order:
+/// 1. Two adjacent lines both equal to `BLOCK_BEGIN` (the labelled fence) -
+///    everything between them is removed, fences included.
+/// 2. Fallback: any line containing `ALIAS_MARKER` is removed individually.
+///    Catches the case where the user kept the alias line but deleted the
+///    fence comments.
+pub fn uninstall_aliases(rc_path: &Path) -> anyhow::Result<bool> {
+    if !os_side_effects_allowed() {
+        return Ok(false);
+    }
+    let existing = match std::fs::read_to_string(rc_path) {
+        Ok(s) => s,
+        Err(_) => return Ok(false),
+    };
+    let (new_contents, changed) = strip_paste_guard_block(&existing);
+    if !changed {
+        return Ok(false);
+    }
+    atomic_write(rc_path, new_contents.as_bytes())?;
+    Ok(true)
+}
+
+/// Pure string transform behind `uninstall_aliases`. Lets the tests exercise
+/// the parser without hitting the filesystem.
+pub fn strip_paste_guard_block(contents: &str) -> (String, bool) {
+    let lines: Vec<&str> = contents.split_inclusive('\n').collect();
+    let mut out: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut changed = false;
+    let mut i = 0;
+    while i < lines.len() {
+        if lines[i].trim_end() == BLOCK_BEGIN {
+            // Find the matching closing fence at the same trimmed value.
+            // `BLOCK_BEGIN` and `BLOCK_END` are identical strings so the
+            // pair is just the next occurrence.
+            let mut j = i + 1;
+            while j < lines.len() && lines[j].trim_end() != BLOCK_END {
+                j += 1;
+            }
+            if j < lines.len() {
+                // Skip lines [i, j] inclusive.
+                changed = true;
+                i = j + 1;
+                continue;
+            }
+            // Unterminated fence - leave the file alone rather than chew
+            // an arbitrary tail; user can clean by hand.
+        }
+        if lines[i].contains(ALIAS_MARKER) {
+            changed = true;
+            i += 1;
+            continue;
+        }
+        out.push(lines[i]);
+        i += 1;
+    }
+    // Collapse a run of consecutive blank lines that the removal may have
+    // produced. Conservative: keep at most one blank between non-blank
+    // lines.
+    let joined: String = out.into_iter().collect();
+    let collapsed = collapse_blank_runs(&joined);
+    (collapsed, changed)
+}
+
+fn collapse_blank_runs(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut blank_run = 0;
+    for line in s.split_inclusive('\n') {
+        if line.trim().is_empty() {
+            blank_run += 1;
+            if blank_run <= 1 {
+                out.push_str(line);
+            }
+        } else {
+            blank_run = 0;
+            out.push_str(line);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snippet_bash_format() {
+        let s = render_alias_snippet(Shell::Bash, &["claude", "codex"]);
+        assert!(s.contains("alias claude='secret-stripper paste-guard -- claude'"));
+        assert!(s.contains("alias codex='secret-stripper paste-guard -- codex'"));
+        assert!(s.contains(BLOCK_BEGIN));
+        assert!(s.contains(BLOCK_END));
+    }
+
+    #[test]
+    fn snippet_fish_format_differs() {
+        let s = render_alias_snippet(Shell::Fish, &["claude"]);
+        assert!(s.contains("alias claude 'secret-stripper paste-guard -- claude'"));
+    }
+
+    #[test]
+    fn display_name_round_trip() {
+        assert_eq!(Shell::Bash.display_name(), "bash");
+        assert_eq!(Shell::Zsh.display_name(), "zsh");
+        assert_eq!(Shell::Fish.display_name(), "fish");
+    }
+
+    #[test]
+    fn strip_removes_fenced_block() {
+        let input = "export FOO=1\n\
+                     # ---- secret-stripper paste-guard ----\n\
+                     alias claude='secret-stripper paste-guard -- claude'\n\
+                     alias codex='secret-stripper paste-guard -- codex'\n\
+                     # ---- secret-stripper paste-guard ----\n\
+                     export BAR=2\n";
+        let (out, changed) = strip_paste_guard_block(input);
+        assert!(changed);
+        assert!(!out.contains("secret-stripper paste-guard"));
+        assert!(out.contains("export FOO=1"));
+        assert!(out.contains("export BAR=2"));
+    }
+
+    #[test]
+    fn strip_removes_orphan_alias_without_fence() {
+        let input = "export FOO=1\n\
+                     alias claude='secret-stripper paste-guard -- claude'\n\
+                     export BAR=2\n";
+        let (out, changed) = strip_paste_guard_block(input);
+        assert!(changed);
+        assert!(!out.contains("secret-stripper paste-guard"));
+        assert!(out.contains("export FOO=1"));
+        assert!(out.contains("export BAR=2"));
+    }
+
+    #[test]
+    fn strip_no_op_when_clean() {
+        let input = "export FOO=1\nexport BAR=2\n";
+        let (out, changed) = strip_paste_guard_block(input);
+        assert!(!changed);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn strip_collapses_blank_runs() {
+        let input = "export FOO=1\n\n\n\n# ---- secret-stripper paste-guard ----\n\
+                     alias x='secret-stripper paste-guard -- x'\n\
+                     # ---- secret-stripper paste-guard ----\n\n\n\nexport BAR=2\n";
+        let (out, changed) = strip_paste_guard_block(input);
+        assert!(changed);
+        // No more than one consecutive blank line remains.
+        assert!(!out.contains("\n\n\n"));
+    }
+
+    #[test]
+    fn uninstall_aliases_round_trip_with_real_file() {
+        let saved = std::env::var_os(ENV_NO_OS);
+        std::env::remove_var(ENV_NO_OS);
+
+        let dir = tempfile::tempdir().unwrap();
+        let rc = dir.path().join(".bashrc");
+        let original = "export FOO=1\nexport BAR=2\n";
+        let with_block = format!(
+            "{}# ---- secret-stripper paste-guard ----\n\
+             alias claude='secret-stripper paste-guard -- claude'\n\
+             # ---- secret-stripper paste-guard ----\n",
+            original
+        );
+        std::fs::write(&rc, &with_block).unwrap();
+
+        let removed = uninstall_aliases(&rc).unwrap();
+        assert!(removed);
+        let after = std::fs::read_to_string(&rc).unwrap();
+        assert!(!after.contains("secret-stripper paste-guard"));
+        assert!(after.contains("export FOO=1"));
+
+        if let Some(v) = saved {
+            std::env::set_var(ENV_NO_OS, v);
+        }
+    }
+
+    #[test]
+    fn uninstall_no_op_when_env_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let rc = dir.path().join(".bashrc");
+        std::fs::write(&rc, "alias x='secret-stripper paste-guard -- x'\n").unwrap();
+        std::env::set_var(ENV_NO_OS, "1");
+        let removed = uninstall_aliases(&rc).unwrap();
+        std::env::remove_var(ENV_NO_OS);
+        assert!(!removed);
+        // File untouched.
+        assert!(std::fs::read_to_string(&rc)
+            .unwrap()
+            .contains("secret-stripper paste-guard"));
+    }
+}

--- a/tests/paste_guard_parser.rs
+++ b/tests/paste_guard_parser.rs
@@ -1,0 +1,22 @@
+use secret_stripper::config::Config;
+use secret_stripper::detector::Detector;
+use secret_stripper::redact_cli::redact_with;
+
+// The parser type lives in the binary crate and is unit-tested next to its
+// source. From the lib we exercise the redact pipeline the parser feeds
+// payloads through, with a realistic AWS-shaped paste.
+#[test]
+fn paste_payload_with_aws_key_is_redacted() {
+    let mut cfg = Config {
+        onboarding_done: true,
+        ..Config::default()
+    };
+    secret_stripper::detector::presets::Preset::Balanced.apply(&mut cfg);
+    let det = Detector::from_config(&cfg);
+
+    let payload = "Here are my creds: AKIAIOSFODNN7EXAMPLE and a secret = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    let (out, names) = redact_with(&det, &cfg, payload);
+    assert_ne!(out, payload);
+    assert!(!out.contains("AKIAIOSFODNN7EXAMPLE"), "key leaked: {}", out);
+    assert!(!names.is_empty());
+}

--- a/tests/redact_cli.rs
+++ b/tests/redact_cli.rs
@@ -1,0 +1,37 @@
+use secret_stripper::config::Config;
+use secret_stripper::detector::Detector;
+use secret_stripper::redact_cli::redact_with;
+
+fn fresh_cfg() -> Config {
+    let mut c = Config {
+        onboarding_done: true,
+        ..Config::default()
+    };
+    secret_stripper::detector::presets::Preset::Balanced.apply(&mut c);
+    c
+}
+
+#[test]
+fn pipe_redacts_openai_key() {
+    let cfg = fresh_cfg();
+    let det = Detector::from_config(&cfg);
+    let input = "API key for testing: sk-proj-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghij\nend\n";
+    let (out, names) = redact_with(&det, &cfg, input);
+    assert_ne!(out, input, "expected the secret to be redacted");
+    assert!(
+        !out.contains("sk-proj-abcdefghijklmnopqrstuvwxyz"),
+        "raw key leaked: {}",
+        out
+    );
+    assert!(!names.is_empty(), "expected at least one matched pattern");
+}
+
+#[test]
+fn pipe_passes_clean_text_through_unchanged() {
+    let cfg = fresh_cfg();
+    let det = Detector::from_config(&cfg);
+    let input = "this is just a comment about the weather today\n";
+    let (out, names) = redact_with(&det, &cfg, input);
+    assert_eq!(out, input);
+    assert!(names.is_empty());
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits:
  <type>(<optional-scope>): <imperative summary>
Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
Example: feat(detect): add IBAN checksum validation
See CONTRIBUTING.md for the full convention.
-->

## Summary

Adds two subcommands so AI TUIs no longer require a hotkey trigger to be protected. AI tools like Claude Code, Codex CLI, Gemini CLI, aider, Continue, and opencode take over the terminal in raw mode and read stdin directly, so a shell-level paste hook can't see what flows in. 

`paste-guard` wraps the child inside a PTY, parses bracketed-paste sequences on the user-to-child stream, runs the payload through the existing detector / redact pipeline, and forwards. Typing is never modified. 
`redact` exposes the same pipeline as a stdin -> stdout primitive for ad-hoc piping. `init` detects installed AI TUIs and prints a ready-to-copy shell alias snippet for the user's shell; it never writes to the shell rc. 
`uninstall` trims the labelled alias block when present.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or output)
- [ ] Refactor / internal change (no behavior change)
- [ ] Documentation, tooling, or CI

## Testing

- [x] `just ci` is green locally (format, lint, tests)
- [x] Added or updated tests for this change
- [x] Manually verified the behavior end-to-end

Verified on:

- [x] Linux
- [ ] macOS
- [ ] Windows
