### PR TITLE
feat(redact): add placeholder-value redaction style

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Pick how detected secrets are replaced from `secret-stripper menu` -> **Redactio
 | **Marker** (default) | `aws=[REDACTED]` - uses a configurable marker string (eight presets + custom) |
 | **Drop** | `aws=` - removes the matched bytes entirely |
 | **Typed** | `aws=[AWS_ACCESS_KEY_ID]` - replaces each span with a tag derived from the matched pattern name |
+| **Placeholder** | `aws=AKIAIOSFODNN7EXAMPLE` - swaps in a realistic but fake sample value for the matched pattern (an email becomes `user@example.com`, a Stripe key `sk_test_4eC39HqLyjWDarjtT1zdp7dc`) |
 
 The same setting applies to the hotkey trigger, the `redact` pipeline subcommand, and the `paste-guard` AI-TUI wrapper.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub enum RedactStyle {
     Marker,
     Drop,
     Typed,
+    Placeholder,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/detector/mod.rs
+++ b/src/detector/mod.rs
@@ -2,6 +2,7 @@ pub mod custom;
 pub mod deep_scan;
 pub mod entropy;
 pub mod patterns;
+pub mod placeholders;
 pub mod presets;
 pub mod redact;
 pub mod validators;

--- a/src/detector/placeholders.rs
+++ b/src/detector/placeholders.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use super::patterns;
+use super::redact::name_to_tag;
+
+// Sample values for the `Placeholder` redaction style. Resolution is exact
+// pattern name, then the pattern's category, then the typed tag. The mapping is
+// static and deterministic: the same name always yields the same value.
+//
+// Idempotency is a fixed point, not the absence of a match. Card and IBAN
+// samples are chosen to fail their checksum validator, so a re-scan does not
+// detect them at all. Provider keys, email and IP samples re-match their own
+// pattern but map back to themselves, so a second pass never changes the text.
+// Private-key blocks and deep-scan findings have no realistic single-line form
+// (a multi-line value would be repeated once per newline fragment), so they are
+// left uncurated and fall through to the typed tag.
+
+/// Fail-closed value for the path where a secret was detected but no span is
+/// known (a deep-scan-only hit). Inert: it matches no pattern on a re-scan.
+pub const GENERIC: &str = "example-redacted-value";
+
+/// Exact pattern name -> sample value.
+pub(crate) const CURATED: &[(&str, &str)] = &[
+    ("AWS Access Key ID", "AKIAIOSFODNN7EXAMPLE"),
+    (
+        "GitHub Personal Access Token",
+        "ghp_0123456789abcdefghijklmnopqrstuvwxyz",
+    ),
+    ("GitLab Personal Access Token", "glpat-0123456789abcdefghij"),
+    ("Stripe API Key", "sk_test_4eC39HqLyjWDarjtT1zdp7dc"),
+    (
+        "OpenAI API Key",
+        "sk-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV",
+    ),
+    ("Slack Bot Token", "xoxb-0000000000-0000000000-abcdABCD1234"),
+    ("Google API Key", "AIzaSyDaGkExAmpLe0123456789abcdefghijkl"),
+    (
+        "JWT Token",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    ),
+    ("Email Address", "user@example.com"),
+    ("IPv4 Address", "192.0.2.1"),
+    ("IPv6 Address", "2001:db8::1"),
+    ("IPv6 Address (compressed)", "2001:db8::1"),
+    ("Visa Card", "4111 1111 1111 1112"),
+    ("Mastercard Card", "5555 5555 5555 4445"),
+    ("American Express Card", "3782 822463 10006"),
+    ("IBAN", "DE00370400440532013000"),
+    ("IBAN (Germany)", "DE00370400440532013000"),
+    ("Phone Number (US)", "(555) 555-0123"),
+    ("International Phone (E.164)", "+41 44 668 18 00"),
+];
+
+/// Pattern category -> generic family value for the uncurated long tail. Values
+/// are low-entropy and carry no provider prefix or checksum, so they re-match
+/// nothing. PII families are intentionally absent: a category cannot tell an
+/// email apart from a phone, so PII is curated by name above.
+pub(crate) const CATEGORY: &[(&str, &str)] = &[
+    ("API Secret", "example-api-key-value"),
+    ("Auth Token", "example-auth-token-value"),
+    ("OAuth Token", "example-oauth-token-value"),
+    ("OAuth Secret", "example-oauth-secret-value"),
+    ("Cloud Secret", "example-cloud-key-value"),
+    ("Payment Secret", "example-payment-key-value"),
+    ("Messaging Token", "example-messaging-token-value"),
+    ("VCS Token", "example-vcs-token-value"),
+];
+
+fn category_index() -> &'static HashMap<&'static str, &'static str> {
+    static IDX: OnceLock<HashMap<&'static str, &'static str>> = OnceLock::new();
+    IDX.get_or_init(|| {
+        patterns::all_patterns()
+            .iter()
+            .map(|p| (p.name, p.category))
+            .collect()
+    })
+}
+
+pub(crate) fn placeholder_for(name: &str) -> String {
+    if let Some(&(_, value)) = CURATED.iter().find(|&&(n, _)| n == name) {
+        return value.to_string();
+    }
+    if let Some(category) = category_index().get(name) {
+        if let Some(&(_, value)) = CATEGORY.iter().find(|&&(c, _)| c == *category) {
+            return value.to_string();
+        }
+    }
+    name_to_tag(name)
+}

--- a/src/detector/redact.rs
+++ b/src/detector/redact.rs
@@ -109,10 +109,18 @@ pub fn redact_with_spans(
     let mut merged: Vec<(usize, usize, &str)> = Vec::with_capacity(spans.len());
     for (s, e, name) in spans {
         match merged.last_mut() {
-            // Typed mode keeps spans with different names distinct so each
-            // gets its own marker; Marker / Drop merge unconditionally as
-            // before.
-            Some(last) if s <= last.1 && (style != RedactStyle::Typed || last.2 == name) => {
+            // A true byte overlap (s < last.1) can never become two separate
+            // markers, so it always fuses and the earlier span's name wins; this
+            // also stops the emit loop below from slicing backwards. Adjacent
+            // spans (s == last.1) fuse unconditionally for Marker / Drop, and for
+            // Typed / Placeholder only when the name matches, so distinct
+            // neighbouring secrets each keep their own marker.
+            Some(last)
+                if s < last.1
+                    || (s == last.1
+                        && (!matches!(style, RedactStyle::Typed | RedactStyle::Placeholder)
+                            || last.2 == name)) =>
+            {
                 if e > last.1 {
                     last.1 = e;
                 }
@@ -129,6 +137,7 @@ pub fn redact_with_spans(
             RedactStyle::Marker => marker.to_string(),
             RedactStyle::Drop => String::new(),
             RedactStyle::Typed => name_to_tag(name),
+            RedactStyle::Placeholder => super::placeholders::placeholder_for(name),
         };
         // Preserve line structure: if the span straddles newlines (a token a
         // human soft-wrapped, or a multi-line block pattern), emit one marker
@@ -587,5 +596,154 @@ mod tests {
         assert_eq!(name_to_tag("---"), "[SECRET]");
         assert_eq!(name_to_tag("__hello__"), "[HELLO]");
         assert_eq!(name_to_tag("a"), "[A]");
+    }
+
+    fn redact_via_detector(
+        det: &crate::detector::Detector,
+        cfg: &crate::config::Config,
+        text: &str,
+    ) -> String {
+        let r = det.scan(text);
+        let entropy: Vec<&str> = r
+            .high_entropy_tokens
+            .iter()
+            .map(|(t, _)| t.as_str())
+            .collect();
+        let mut deep: Vec<(usize, usize, &str)> = r
+            .deep_findings
+            .iter()
+            .filter_map(|f| f.span.map(|(s, e)| (s, e, f.finding_type)))
+            .collect();
+        deep.extend(r.extra_spans.iter().copied());
+        redact_with_spans(
+            text,
+            &r.matched_spans,
+            &entropy,
+            &deep,
+            det.allowlist(),
+            RedactStyle::Placeholder,
+            &cfg.redact_pattern,
+        )
+    }
+
+    #[test]
+    fn placeholder_style_uses_curated_value() {
+        let p = pat("Email Address", r"john\.doe@corp\.com");
+        let result = redact_text(
+            "contact john.doe@corp.com now",
+            &[&p],
+            &[],
+            &[],
+            RedactStyle::Placeholder,
+            "",
+        );
+        assert_eq!(result, "contact user@example.com now");
+    }
+
+    #[test]
+    fn placeholder_style_no_merge_different_names() {
+        let p1 = pat("Email Address", "EMAIL");
+        let p2 = pat("AWS Access Key ID", "AWS");
+        let result = redact_text(
+            "EMAILAWS tail",
+            &[&p1, &p2],
+            &[],
+            &[],
+            RedactStyle::Placeholder,
+            "",
+        );
+        // Adjacent spans of different names must not merge: each secret gets its
+        // own sample value.
+        assert_eq!(result, "user@example.comAKIAIOSFODNN7EXAMPLE tail");
+    }
+
+    #[test]
+    fn placeholder_style_merges_same_name() {
+        let p1 = pat("Email Address", "abc");
+        let p2 = pat("Email Address", "bc");
+        let result = redact_text(
+            "xx abc yy",
+            &[&p1, &p2],
+            &[],
+            &[],
+            RedactStyle::Placeholder,
+            "",
+        );
+        assert_eq!(result, "xx user@example.com yy");
+        assert_eq!(result.matches("user@example.com").count(), 1);
+    }
+
+    #[test]
+    fn placeholder_validator_fakes_do_not_self_match() {
+        // The card and IBAN samples are format-valid but fail their checksum
+        // validator, so a re-scan does not detect them at all.
+        let cfg = crate::config::Config::default();
+        let det = crate::detector::Detector::from_config(&cfg);
+        for name in [
+            "Visa Card",
+            "Mastercard Card",
+            "American Express Card",
+            "IBAN",
+            "IBAN (Germany)",
+        ] {
+            let value = crate::detector::placeholders::placeholder_for(name);
+            let r = det.scan(&value);
+            assert!(
+                !r.has_secrets,
+                "{name} sample '{value}' was re-detected: {:?}",
+                r.matched_patterns
+            );
+        }
+    }
+
+    #[test]
+    fn placeholder_style_idempotent_fixed_point() {
+        // Every curated and category sample value must be a redaction fixed
+        // point: redacting it again yields the same text. This fails the build
+        // if a value cross-matches a different pattern or grows on re-scan.
+        // Checked under both the install default (deep scan / entropy off) and
+        // the stricter superset (both on), since a user may run either and
+        // idempotency must not depend on those toggles.
+        let strict = crate::config::Config {
+            enable_deep_scan: true,
+            enable_entropy: true,
+            ..crate::config::Config::default()
+        };
+        for cfg in [crate::config::Config::default(), strict] {
+            let det = crate::detector::Detector::from_config(&cfg);
+            let entries = crate::detector::placeholders::CURATED
+                .iter()
+                .chain(crate::detector::placeholders::CATEGORY.iter());
+            for &(key, value) in entries {
+                let once = redact_via_detector(&det, &cfg, value);
+                assert_eq!(once, value, "sample for '{key}' is not a fixed point");
+                let twice = redact_via_detector(&det, &cfg, &once);
+                assert_eq!(twice, once, "sample for '{key}' changed on second pass");
+            }
+        }
+    }
+
+    #[test]
+    fn generic_placeholder_scans_clean() {
+        let cfg = crate::config::Config::default();
+        let det = crate::detector::Detector::from_config(&cfg);
+        assert!(!det.scan(crate::detector::placeholders::GENERIC).has_secrets);
+    }
+
+    #[test]
+    fn placeholder_style_overlapping_spans_fuse() {
+        // Different-name spans that truly overlap must fuse into one (the first
+        // name wins) instead of slicing backwards in the emit loop.
+        let p1 = pat("Email Address", "abcdef");
+        let p2 = pat("AWS Access Key ID", "cde");
+        let result = redact_text(
+            "xx abcdef yy",
+            &[&p1, &p2],
+            &[],
+            &[],
+            RedactStyle::Placeholder,
+            "",
+        );
+        assert_eq!(result, "xx user@example.com yy");
     }
 }

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -1192,6 +1192,12 @@ lang_strings! {
         IT => "Etichetta tipizzata",
         ES => "Etiqueta tipada",
     }
+    rs_style_placeholder {
+        EN => "Placeholder",
+        FR => "Valeur fictive",
+        IT => "Valore fittizio",
+        ES => "Valor ficticio",
+    }
     help_rs_style_marker {
         EN => "Replace each secret with a configurable marker (e.g. [REDACTED])",
         FR => "Remplacer chaque secret par un marqueur configurable (ex : [REDACTED])",
@@ -1209,6 +1215,12 @@ lang_strings! {
         FR => "Remplacer chaque secret par une étiquette typée (ex : [EMAIL_ADDRESS], [AWS_ACCESS_KEY_ID])",
         IT => "Sostituisci ogni segreto con un'etichetta tipizzata (es. [EMAIL_ADDRESS], [AWS_ACCESS_KEY_ID])",
         ES => "Reemplaza cada secreto con una etiqueta tipada (p. ej. [EMAIL_ADDRESS], [AWS_ACCESS_KEY_ID])",
+    }
+    help_rs_style_placeholder {
+        EN => "Replace each secret with a realistic but fake sample value (e.g. user@example.com, AKIAIOSFODNN7EXAMPLE)",
+        FR => "Remplacer chaque secret par une valeur d'exemple réaliste mais fictive (ex : user@example.com, AKIAIOSFODNN7EXAMPLE)",
+        IT => "Sostituisci ogni segreto con un valore di esempio realistico ma falso (es. user@example.com, AKIAIOSFODNN7EXAMPLE)",
+        ES => "Reemplaza cada secreto con un valor de ejemplo realista pero falso (p. ej. user@example.com, AKIAIOSFODNN7EXAMPLE)",
     }
     help_rs_preset {
         EN => "Use this marker to redact detected secrets",

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,18 +249,24 @@ fn run_trigger() -> anyhow::Result<()> {
         + result.high_entropy_tokens.len();
 
     // Fallback: detection found something but the redactor produced an
-    // identical string. This happens when only deep-scan caught the secret
-    // (DeepFinding does not carry the matched span). Fail-closed per style:
-    // Marker writes the configured marker; Typed writes [SECRET]; Drop empties
-    // the clipboard and force-notifies regardless of `silent` so an empty
-    // clipboard does not look like silent breakage.
+    // identical string. For Marker/Typed/Drop that only happens when no span was
+    // located (a deep-scan-only hit, since DeepFinding may carry no span), so
+    // fail closed. Placeholder sample values can legitimately equal the original
+    // secret (a fixed point), so for that style only fail closed when there was
+    // genuinely no span to redact. Drop empties the clipboard and force-notifies
+    // regardless of `silent` so an empty clipboard does not look like breakage.
+    let had_spans =
+        !result.matched_spans.is_empty() || !entropy_tokens.is_empty() || !deep_spans.is_empty();
+    let redaction_noop = *redacted == *text
+        && !(matches!(config.redact_style, config::RedactStyle::Placeholder) && had_spans);
     let drop_fallback_fired =
-        *redacted == *text && matches!(config.redact_style, config::RedactStyle::Drop);
-    let to_write: zeroize::Zeroizing<String> = if *redacted == *text {
+        redaction_noop && matches!(config.redact_style, config::RedactStyle::Drop);
+    let to_write: zeroize::Zeroizing<String> = if redaction_noop {
         let fallback = match config.redact_style {
             config::RedactStyle::Marker => config.redact_pattern.clone(),
             config::RedactStyle::Typed => "[SECRET]".to_string(),
             config::RedactStyle::Drop => String::new(),
+            config::RedactStyle::Placeholder => detector::placeholders::GENERIC.to_string(),
         };
         zeroize::Zeroizing::new(fallback)
     } else {

--- a/src/redact_cli.rs
+++ b/src/redact_cli.rs
@@ -51,15 +51,20 @@ pub fn redact_with(detector: &Detector, cfg: &Config, text: &str) -> (String, Ve
     }
 
     // Fallback: deep-scan caught it but the redactor produced an identical
-    // string (no span info). Replace the whole input so the secret cannot
-    // survive the round-trip. Style-aware: Marker uses the configured marker,
-    // Typed uses [SECRET] (the originating name is unrecoverable here), Drop
-    // empties the output. Mirrors the trigger flow in main.rs::run_trigger.
-    let final_text = if redacted == text {
+    // string. For Marker/Typed/Drop that means no span was located, so replace
+    // the whole input to fail closed. Placeholder sample values can equal the
+    // original secret (a fixed point), so for that style only fail closed when
+    // there was genuinely no span to redact. Mirrors main.rs::run_trigger.
+    let had_spans =
+        !result.matched_spans.is_empty() || !entropy_tokens.is_empty() || !deep_spans.is_empty();
+    let redaction_noop =
+        redacted == text && !(matches!(cfg.redact_style, RedactStyle::Placeholder) && had_spans);
+    let final_text = if redaction_noop {
         match cfg.redact_style {
             RedactStyle::Marker => cfg.redact_pattern.clone(),
             RedactStyle::Typed => "[SECRET]".to_string(),
             RedactStyle::Drop => String::new(),
+            RedactStyle::Placeholder => detector::placeholders::GENERIC.to_string(),
         }
     } else {
         redacted
@@ -80,4 +85,32 @@ pub fn run_redact() -> anyhow::Result<()> {
     let mut out = stdout.lock();
     out.write_all(redacted.as_bytes())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn placeholder_detector() -> (Config, Detector) {
+        let cfg = Config {
+            redact_style: RedactStyle::Placeholder,
+            ..Config::default()
+        };
+        let det = Detector::from_config(&cfg);
+        (cfg, det)
+    }
+
+    #[test]
+    fn placeholder_round_trip_is_a_stable_fixed_point() {
+        // A Placeholder sample can equal the original secret, so the redactor
+        // returns text unchanged on a second pass. The fail-closed fallback must
+        // not mistake that for a no-op and clobber the whole input.
+        let (cfg, det) = placeholder_detector();
+        let input = "aws AKIA1234567890ABCDEF email jane.doe@corp.com";
+        let (once, _) = redact_with(&det, &cfg, input);
+        assert_eq!(once, "aws AKIAIOSFODNN7EXAMPLE email user@example.com");
+        let (twice, _) = redact_with(&det, &cfg, &once);
+        assert_eq!(twice, once);
+        assert_ne!(twice, detector::placeholders::GENERIC);
+    }
 }

--- a/src/tui/chrome.rs
+++ b/src/tui/chrome.rs
@@ -76,6 +76,7 @@ impl StatusSnapshot {
             }
             crate::config::RedactStyle::Drop => lang.rs_style_drop().to_string(),
             crate::config::RedactStyle::Typed => lang.rs_style_typed().to_string(),
+            crate::config::RedactStyle::Placeholder => lang.rs_style_placeholder().to_string(),
         };
         Self {
             hotkey: config.hotkey.clone(),

--- a/src/tui/redact_style.rs
+++ b/src/tui/redact_style.rs
@@ -35,9 +35,10 @@ pub fn show(terminal: &mut ratatui::DefaultTerminal, config: &mut Config) -> any
         RedactStyle::Marker => 0usize,
         RedactStyle::Drop => 1usize,
         RedactStyle::Typed => 2usize,
+        RedactStyle::Placeholder => 3usize,
     };
-    let style_total = 4usize;
-    let style_back = 3usize;
+    let style_total = 5usize;
+    let style_back = 4usize;
 
     let custom_idx = PRESETS.len();
     let back_idx = custom_idx + 1;
@@ -56,6 +57,7 @@ pub fn show(terminal: &mut ratatui::DefaultTerminal, config: &mut Config) -> any
                     0 => config.lang.help_rs_style_marker(),
                     1 => config.lang.help_rs_style_drop(),
                     2 => config.lang.help_rs_style_typed(),
+                    3 => config.lang.help_rs_style_placeholder(),
                     _ => config.lang.help_back(),
                 };
                 terminal.draw(|f| {
@@ -78,7 +80,7 @@ pub fn show(terminal: &mut ratatui::DefaultTerminal, config: &mut Config) -> any
                         Line::from(spans)
                     };
                     let cur = config.redact_style;
-                    let mut lines: Vec<Line> = Vec::with_capacity(5);
+                    let mut lines: Vec<Line> = Vec::with_capacity(6);
                     lines.push(style_row(
                         0,
                         config.lang.rs_style_marker(),
@@ -93,6 +95,11 @@ pub fn show(terminal: &mut ratatui::DefaultTerminal, config: &mut Config) -> any
                         2,
                         config.lang.rs_style_typed(),
                         cur == RedactStyle::Typed,
+                    ));
+                    lines.push(style_row(
+                        3,
+                        config.lang.rs_style_placeholder(),
+                        cur == RedactStyle::Placeholder,
                     ));
                     lines.push(Line::from(""));
                     let is_back_sel = style_selected == style_back;
@@ -145,6 +152,14 @@ pub fn show(terminal: &mut ratatui::DefaultTerminal, config: &mut Config) -> any
                             2 => {
                                 if config.redact_style != RedactStyle::Typed {
                                     config.redact_style = RedactStyle::Typed;
+                                    config.save()?;
+                                    changed = true;
+                                }
+                                break;
+                            }
+                            3 => {
+                                if config.redact_style != RedactStyle::Placeholder {
+                                    config.redact_style = RedactStyle::Placeholder;
                                     config.save()?;
                                     changed = true;
                                 }

--- a/tests/fixtures/corpus/negatives.txt
+++ b/tests/fixtures/corpus/negatives.txt
@@ -261,3 +261,9 @@ A plain 16-digit order number 1234567890123456 is not a card.
 # The separator-less 12-hex MAC form was removed - it redacted git short
 # SHAs / hex ids. A bare 12-hex run must now stay quiet.
 Build commit a1b2c3d4e5f6 deployed; blob id 0e02b2c3d479 cached.
+
+# === FP lock: Placeholder-style sample values stay inert ===
+# The Placeholder redaction style emits these as fake examples. Each is
+# format-valid but fails its checksum (Amex Mod-10, IBAN Mod-97), so a
+# re-scan of redacted output must not detect them.
+Amex sample 3782 822463 10006 and IBAN sample DE00370400440532013000 here.


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits:
  <type>(<optional-scope>): <imperative summary>
Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
Example: feat(detect): add IBAN checksum validation
See CONTRIBUTING.md for the full convention.
-->

## Summary

Adds a `Placeholder` redaction style: each detected secret is replaced with a realistic but non-functional sample value (AWS key -> `AKIAIOSFODNN7EXAMPLE`, email -> `user@example.com`) instead of a generic marker. Static, deterministic, idempotent. Default stays `Marker`, so existing configs are unaffected.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or output)
- [ ] Refactor / internal change (no behavior change)
- [ ] Documentation, tooling, or CI

## Changes

- New `RedactStyle::Placeholder` + a name-keyed sample registry (`detector/placeholders.rs`); curated provider keys/email/IP, generic per-category fallback, then the typed tag for the long tail.
- Idempotent by construction: card/IBAN samples fail their checksum so they vanish on re-scan, others re-match to themselves (fixed point).
- **Reviewer focus:** hardens the span-merge loop in `redact.rs` (fuses overlapping different-name spans) - this also fixes a latent backward-slice panic that affected `Typed` mode; and the fail-closed fallback in `main.rs`/`redact_cli.rs` now distinguishes a real no-op from a Placeholder fixed point.
- Four-locale i18n + TUI picker entry; no config migration.

## Testing

- [x] `just ci` is green locally (format, lint, tests)
- [x] Added or updated tests for this change
- [x] Manually verified the behavior end-to-end

Verified on:

- [x] Linux
- [ ] macOS
- [ ] Windows
