### PR TITLE
feat(image): redact secrets in clipboard screenshots via OCR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "env_logger",
+ "image",
  "log",
  "notify-rust",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ patterns-doc = []
 
 [dependencies]
 arboard = { version = "3.6.1", features = ["wayland-data-control"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [macOS setup](#macos-setup)
   - [Windows setup](#windows-setup)
 - [What It Detects](#what-it-detects)
+- [Redact screenshots](#redact-screenshots)
 - [Auto-redact paste into AI TUIs](#auto-redact-paste-into-ai-tuis)
 - [Contributing](#contributing)
 - [Star history](#star-history)
@@ -167,6 +168,28 @@ Pick how detected secrets are replaced from `secret-stripper menu` -> **Redactio
 | **Placeholder** | `aws=AKIAIOSFODNN7EXAMPLE` - swaps in a realistic but fake sample value for the matched pattern (an email becomes `user@example.com`, a Stripe key `sk_test_4eC39HqLyjWDarjtT1zdp7dc`) |
 
 The same setting applies to the hotkey trigger, the `redact` pipeline subcommand, and the `paste-guard` AI-TUI wrapper.
+
+---
+
+## Redact screenshots
+
+Secrets often live in screenshots, not just text - a terminal grab, a config pane, an API dashboard. When you trigger the hotkey and the clipboard holds an image instead of text, Secret Stripper OCRs the image, runs the same detector it uses for text, and paints a solid black box over only the words that contain a secret. The redacted image is written back to the clipboard. Clean parts of the image are left untouched - the whole screenshot is never blacked out.
+
+Supported on Linux only - both X11 and Wayland. On macOS and Windows the hotkey still does text redaction; a clipboard image is left untouched.
+
+When an image is on the clipboard, the hotkey redacts the image even if you have text highlighted - so `screenshot -> hotkey` just works.
+
+It needs the [`tesseract`](https://github.com/tesseract-ocr/tesseract) OCR CLI on your `PATH`. It is an optional runtime dependency: everything else works without it.
+
+```bash
+sudo pacman -S tesseract tesseract-data-eng    # Arch
+sudo apt install tesseract-ocr                  # Debian / Ubuntu
+sudo dnf install tesseract                      # Fedora
+```
+
+It fails closed: if `tesseract` is missing, the image cannot be read, or a detected secret cannot be located, the clipboard is left untouched and you get a notification - the original image is never silently passed through and never wiped. OCR makes this path slower than the instant text path (roughly half a second to a couple of seconds for a full screenshot), so wait for the notification before pasting.
+
+Image redaction is off by default. Turn it on from `secret-stripper menu` -> **Detection Settings** -> **Screenshot redaction**, or set `enable_image_scan = true` in `config.toml`.
 
 ---
 

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -43,6 +43,7 @@ impl ClipboardMonitor {
         Some((img.width, img.height, img.bytes.into_owned()))
     }
 
+    #[cfg(target_os = "linux")]
     pub fn replace_image(
         &mut self,
         width: usize,

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -35,4 +35,25 @@ impl ClipboardMonitor {
         self.clipboard.set_text(text.to_string())?;
         Ok(())
     }
+
+    /// Read a bitmap from the clipboard as (width, height, RGBA8 bytes). None when
+    /// the clipboard holds no image.
+    pub fn read_image(&mut self) -> Option<(usize, usize, Vec<u8>)> {
+        let img = self.clipboard.get_image().ok()?;
+        Some((img.width, img.height, img.bytes.into_owned()))
+    }
+
+    pub fn replace_image(
+        &mut self,
+        width: usize,
+        height: usize,
+        bytes: Vec<u8>,
+    ) -> anyhow::Result<()> {
+        self.clipboard.set_image(arboard::ImageData {
+            width,
+            height,
+            bytes: std::borrow::Cow::Owned(bytes),
+        })?;
+        Ok(())
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,10 @@ pub struct Config {
     /// config.toml missing the field also loads as off.
     #[serde(default = "default_enable_entropy")]
     pub enable_entropy: bool,
+    /// Redact secrets visible in a clipboard image (screenshot) via OCR when the
+    /// clipboard holds no text. On by default; needs the `tesseract` CLI present.
+    #[serde(default = "default_enable_image_scan")]
+    pub enable_image_scan: bool,
     pub silent: bool,
     #[serde(default = "default_hotkey")]
     pub hotkey: String,
@@ -160,6 +164,10 @@ fn default_enable_entropy() -> bool {
     false
 }
 
+fn default_enable_image_scan() -> bool {
+    false
+}
+
 fn default_redact_style() -> RedactStyle {
     RedactStyle::Marker
 }
@@ -177,6 +185,7 @@ impl Default for Config {
             entropy_min_len: None,
             enable_deep_scan: false,
             enable_entropy: false,
+            enable_image_scan: false,
             silent: true,
             hotkey: default_hotkey(),
             check_for_updates: true,

--- a/src/image_scan/mod.rs
+++ b/src/image_scan/mod.rs
@@ -1,0 +1,419 @@
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use crate::detector::Detector;
+
+pub struct OcrWord {
+    pub text: String,
+    pub x: u32,
+    pub y: u32,
+    pub w: u32,
+    pub h: u32,
+    pub conf: f32,
+    pub block: u32,
+    pub line: u32,
+}
+
+#[derive(Debug)]
+pub enum OcrError {
+    NotInstalled,
+    Failed(String),
+}
+
+pub trait Ocr {
+    fn recognize(&self, bytes: &[u8], width: u32, height: u32) -> Result<Vec<OcrWord>, OcrError>;
+}
+
+pub struct TesseractOcr;
+
+impl Ocr for TesseractOcr {
+    fn recognize(&self, bytes: &[u8], width: u32, height: u32) -> Result<Vec<OcrWord>, OcrError> {
+        let png = encode_png(bytes, width, height).map_err(|e| OcrError::Failed(e.to_string()))?;
+        let mut tmp = tempfile::Builder::new()
+            .suffix(".png")
+            .tempfile()
+            .map_err(|e| OcrError::Failed(e.to_string()))?;
+        tmp.write_all(&png)
+            .and_then(|()| tmp.flush())
+            .map_err(|e| OcrError::Failed(e.to_string()))?;
+
+        let output = Command::new("tesseract")
+            .arg(tmp.path())
+            .arg("stdout")
+            .args(["-c", "tessedit_create_tsv=1", "--psm", "6"])
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .output();
+
+        let output = match output {
+            Ok(o) => o,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(OcrError::NotInstalled)
+            }
+            Err(e) => return Err(OcrError::Failed(e.to_string())),
+        };
+        if !output.status.success() {
+            return Err(OcrError::Failed(format!(
+                "tesseract exited with {}",
+                output.status
+            )));
+        }
+        let tsv = String::from_utf8_lossy(&output.stdout);
+        if tsv.trim().is_empty() {
+            return Err(OcrError::Failed("empty tesseract output".to_string()));
+        }
+        Ok(parse_tsv(&tsv))
+    }
+}
+
+fn encode_png(bytes: &[u8], width: u32, height: u32) -> image::ImageResult<Vec<u8>> {
+    use image::codecs::png::{CompressionType, FilterType, PngEncoder};
+    use image::{ExtendedColorType, ImageEncoder};
+
+    let mut buf = Vec::new();
+    let encoder =
+        PngEncoder::new_with_quality(&mut buf, CompressionType::Fast, FilterType::Adaptive);
+    encoder.write_image(bytes, width, height, ExtendedColorType::Rgba8)?;
+    Ok(buf)
+}
+
+fn parse_tsv(tsv: &str) -> Vec<OcrWord> {
+    let mut words = Vec::new();
+    for row in tsv.lines().skip(1) {
+        let mut cols = row.splitn(12, '\t');
+        let level = cols.next();
+        let _page = cols.next();
+        let block = cols.next();
+        let _par = cols.next();
+        let lineno = cols.next();
+        let _word = cols.next();
+        let left = cols.next();
+        let top = cols.next();
+        let width = cols.next();
+        let height = cols.next();
+        let conf = cols.next();
+        let text = cols.next();
+
+        let (
+            Some(level),
+            Some(block),
+            Some(lineno),
+            Some(left),
+            Some(top),
+            Some(width),
+            Some(height),
+            Some(conf),
+            Some(text),
+        ) = (level, block, lineno, left, top, width, height, conf, text)
+        else {
+            continue;
+        };
+
+        if level.trim() != "5" {
+            continue;
+        }
+        let Ok(conf) = conf.trim().parse::<f32>() else {
+            continue;
+        };
+        if conf < 0.0 {
+            continue;
+        }
+        let text = text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        let (Some(x), Some(y), Some(w), Some(h)) = (
+            left.trim().parse::<u32>().ok(),
+            top.trim().parse::<u32>().ok(),
+            width.trim().parse::<u32>().ok(),
+            height.trim().parse::<u32>().ok(),
+        ) else {
+            continue;
+        };
+
+        words.push(OcrWord {
+            text: text.to_string(),
+            x,
+            y,
+            w,
+            h,
+            conf,
+            block: block.trim().parse().unwrap_or(0),
+            line: lineno.trim().parse().unwrap_or(0),
+        });
+    }
+    words
+}
+
+pub struct Assembled {
+    pub text: String,
+    pub ranges: Vec<(usize, usize)>,
+}
+
+pub fn assemble(words: &[OcrWord]) -> Assembled {
+    let mut text = String::new();
+    let mut ranges = Vec::with_capacity(words.len());
+    let mut prev: Option<(u32, u32)> = None;
+    for word in words {
+        if let Some(p) = prev {
+            text.push(if (word.block, word.line) == p {
+                ' '
+            } else {
+                '\n'
+            });
+        }
+        let start = text.len();
+        text.push_str(&word.text);
+        ranges.push((start, text.len()));
+        prev = Some((word.block, word.line));
+    }
+    Assembled { text, ranges }
+}
+
+pub fn boxes_for_spans(
+    words: &[OcrWord],
+    ranges: &[(usize, usize)],
+    spans: &[(usize, usize)],
+) -> Vec<(u32, u32, u32, u32)> {
+    let mut boxes: Vec<(u32, u32, u32, u32)> = Vec::new();
+    for &(s, e) in spans {
+        if s >= e {
+            continue;
+        }
+        for (i, &(ws, we)) in ranges.iter().enumerate() {
+            if ws < e && s < we {
+                let word = &words[i];
+                let rect = (word.x, word.y, word.w, word.h);
+                if !boxes.contains(&rect) {
+                    boxes.push(rect);
+                }
+            }
+        }
+    }
+    boxes
+}
+
+pub fn paint_boxes(
+    bytes: &mut [u8],
+    width: u32,
+    height: u32,
+    boxes: &[(u32, u32, u32, u32)],
+    rgba: [u8; 4],
+) -> usize {
+    let width = width as usize;
+    let height = height as usize;
+    let mut painted = 0;
+    for &(bx, by, bw, bh) in boxes {
+        let x0 = (bx as usize).min(width);
+        let y0 = (by as usize).min(height);
+        let x1 = (bx as usize + bw as usize).min(width);
+        let y1 = (by as usize + bh as usize).min(height);
+        if x0 >= x1 || y0 >= y1 {
+            continue;
+        }
+        for py in y0..y1 {
+            for px in x0..x1 {
+                let idx = (py * width + px) * 4;
+                if idx + 4 <= bytes.len() {
+                    bytes[idx..idx + 4].copy_from_slice(&rgba);
+                }
+            }
+        }
+        painted += 1;
+    }
+    painted
+}
+
+pub enum ImageResult {
+    Unavailable,
+    NoSecrets,
+    Redacted {
+        bytes: Vec<u8>,
+        w: u32,
+        h: u32,
+        count: usize,
+    },
+    DetectedUnmappable,
+}
+
+const REDACT_FILL: [u8; 4] = [0, 0, 0, 255];
+
+pub fn redact_image(bytes: &[u8], w: u32, h: u32, ocr: &dyn Ocr, det: &Detector) -> ImageResult {
+    let words = match ocr.recognize(bytes, w, h) {
+        Ok(words) => words,
+        Err(_) => return ImageResult::Unavailable,
+    };
+
+    let assembled = assemble(&words);
+    let text = zeroize::Zeroizing::new(assembled.text);
+    let result = det.scan(&text);
+    if !result.has_secrets {
+        return ImageResult::NoSecrets;
+    }
+
+    let mut spans: Vec<(usize, usize)> = result
+        .matched_spans
+        .iter()
+        .map(|(s, e, _)| (*s, *e))
+        .collect();
+    spans.extend(result.extra_spans.iter().map(|(s, e, _)| (*s, *e)));
+    spans.extend(result.deep_findings.iter().filter_map(|f| f.span));
+    for (token, _) in &result.high_entropy_tokens {
+        if token.is_empty() {
+            continue;
+        }
+        for (s, frag) in text.match_indices(token.as_str()) {
+            spans.push((s, s + frag.len()));
+        }
+    }
+
+    let count = result.matched_patterns.len()
+        + result.deep_findings.len()
+        + result.high_entropy_tokens.len();
+
+    let boxes = boxes_for_spans(&words, &assembled.ranges, &spans);
+    if boxes.is_empty() {
+        return ImageResult::DetectedUnmappable;
+    }
+
+    let mut out = bytes.to_vec();
+    paint_boxes(&mut out, w, h, &boxes, REDACT_FILL);
+    ImageResult::Redacted {
+        bytes: out,
+        w,
+        h,
+        count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    fn word(text: &str, x: u32, line: u32) -> OcrWord {
+        OcrWord {
+            text: text.to_string(),
+            x,
+            y: 10,
+            w: 40,
+            h: 12,
+            conf: 90.0,
+            block: 1,
+            line,
+        }
+    }
+
+    #[test]
+    fn assemble_tracks_byte_offsets_and_separators() {
+        let words = vec![word("foo", 0, 1), word("bar", 50, 1), word("baz", 0, 2)];
+        let a = assemble(&words);
+        assert_eq!(a.text, "foo bar\nbaz");
+        for (i, &(s, e)) in a.ranges.iter().enumerate() {
+            assert_eq!(&a.text[s..e], words[i].text);
+        }
+        assert_eq!(&a.text[a.ranges[0].1..a.ranges[1].0], " ");
+        assert_eq!(&a.text[a.ranges[1].1..a.ranges[2].0], "\n");
+    }
+
+    #[test]
+    fn span_on_separator_selects_no_box() {
+        let words = vec![word("foo", 0, 1), word("bar", 50, 1)];
+        let a = assemble(&words);
+        let sep = a.ranges[0].1;
+        let boxes = boxes_for_spans(&words, &a.ranges, &[(sep, sep + 1)]);
+        assert!(boxes.is_empty());
+    }
+
+    #[test]
+    fn multiword_span_selects_every_overlapped_word() {
+        let words = vec![word("aaa", 0, 1), word("bbb", 50, 1), word("ccc", 100, 1)];
+        let a = assemble(&words);
+        let span = (a.ranges[0].0, a.ranges[1].1);
+        let boxes = boxes_for_spans(&words, &a.ranges, &[span]);
+        assert_eq!(boxes, vec![(0, 10, 40, 12), (50, 10, 40, 12)]);
+    }
+
+    #[test]
+    fn paint_clamps_to_bounds_and_fills_region() {
+        let mut bytes = vec![255u8; 4 * 4 * 4];
+        let painted = paint_boxes(&mut bytes, 4, 4, &[(2, 2, 10, 10)], REDACT_FILL);
+        assert_eq!(painted, 1);
+        let at = |x: usize, y: usize| {
+            let i = (y * 4 + x) * 4;
+            [bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]]
+        };
+        assert_eq!(at(3, 3), [0, 0, 0, 255]);
+        assert_eq!(at(0, 0), [255, 255, 255, 255]);
+        assert_eq!(at(1, 1), [255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn fully_out_of_bounds_box_paints_nothing() {
+        let mut bytes = vec![255u8; 4 * 4 * 4];
+        let painted = paint_boxes(&mut bytes, 4, 4, &[(10, 10, 5, 5)], REDACT_FILL);
+        assert_eq!(painted, 0);
+        assert!(bytes.iter().all(|&b| b == 255));
+    }
+
+    struct StubOcr(Vec<OcrWord>);
+    impl Ocr for StubOcr {
+        fn recognize(&self, _: &[u8], _: u32, _: u32) -> Result<Vec<OcrWord>, OcrError> {
+            Ok(self.0.iter().map(|w| word(&w.text, w.x, w.line)).collect())
+        }
+    }
+
+    struct MissingOcr;
+    impl Ocr for MissingOcr {
+        fn recognize(&self, _: &[u8], _: u32, _: u32) -> Result<Vec<OcrWord>, OcrError> {
+            Err(OcrError::NotInstalled)
+        }
+    }
+
+    #[test]
+    fn redacts_only_the_secret_word_box() {
+        let det = Detector::from_config(&Config::default());
+        let words = vec![
+            word("hello", 0, 1),
+            word("AKIAIOSFODNN7EXAMPLE", 100, 1),
+            word("world", 300, 1),
+        ];
+        let bytes = vec![255u8; 400 * 30 * 4];
+        match redact_image(&bytes, 400, 30, &StubOcr(words), &det) {
+            ImageResult::Redacted {
+                bytes: out, count, ..
+            } => {
+                assert!(count >= 1);
+                let painted_at = |x: usize| {
+                    let i = (10 * 400 + x) * 4;
+                    out[i] == 0 && out[i + 1] == 0 && out[i + 2] == 0
+                };
+                assert!(painted_at(110), "secret word should be painted");
+                assert!(!painted_at(10), "clean word should be untouched");
+                assert!(!painted_at(310), "clean word should be untouched");
+            }
+            _ => panic!("expected a redacted image"),
+        }
+    }
+
+    #[test]
+    fn missing_ocr_is_unavailable() {
+        let det = Detector::from_config(&Config::default());
+        let bytes = vec![0u8; 4 * 4 * 4];
+        assert!(matches!(
+            redact_image(&bytes, 4, 4, &MissingOcr, &det),
+            ImageResult::Unavailable
+        ));
+    }
+
+    #[test]
+    fn clean_image_reports_no_secrets() {
+        let det = Detector::from_config(&Config::default());
+        let words = vec![word("hello", 0, 1), word("world", 80, 1)];
+        let bytes = vec![255u8; 200 * 30 * 4];
+        assert!(matches!(
+            redact_image(&bytes, 200, 30, &StubOcr(words), &det),
+            ImageResult::NoSecrets
+        ));
+    }
+}

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -570,6 +570,21 @@ lang_strings! {
         IT => "Nessun segreto rilevato negli appunti.",
         ES => "No se detectaron secretos en el portapapeles.",
     }
+
+    cli_image_scan_failed {
+        EN => "Could not scan the clipboard image. Clipboard left untouched.",
+        FR => "Impossible d'analyser l'image du presse-papiers. Presse-papiers inchangé.",
+        IT => "Impossibile analizzare l'immagine degli appunti. Appunti invariati.",
+        ES => "No se pudo analizar la imagen del portapapeles. Portapapeles sin cambios.",
+    }
+
+    cli_image_detected_unmappable {
+        EN => "Detected a secret in the image but could not locate it to redact. Clipboard left untouched.",
+        FR => "Secret détecté dans l'image mais impossible de le localiser pour le masquer. Presse-papiers inchangé.",
+        IT => "Segreto rilevato nell'immagine ma impossibile localizzarlo per oscurarlo. Appunti invariati.",
+        ES => "Se detectó un secreto en la imagen pero no se pudo localizar para redactarlo. Portapapeles sin cambios.",
+    }
+
     cli_clipboard_write_failed(cleared: bool, err: &str,) {
         EN => format!("Clipboard write failed{}: {}", if cleared { " (clipboard cleared)" } else { " (and clipboard could NOT be cleared)" }, err),
         FR => format!("Échec d'écriture du presse-papiers{} : {}", if cleared { " (presse-papiers vidé)" } else { " (et le presse-papiers n'a PAS pu être vidé)" }, err),
@@ -1090,6 +1105,21 @@ lang_strings! {
         IT => "Indietro",
         ES => "Atrás",
     }
+    dm_image_scan(on: bool,) {
+        EN => format!("Screenshot redaction: {}", if on { "on" } else { "off" }),
+        FR => format!(
+            "Expurgation des captures d'écran : {}",
+            if on { "activée" } else { "désactivée" }
+        ),
+        IT => format!(
+            "Oscuramento screenshot: {}",
+            if on { "attivo" } else { "disattivo" }
+        ),
+        ES => format!(
+            "Redacción de capturas: {}",
+            if on { "activada" } else { "desactivada" }
+        ),
+    }
     help_dm_categories {
         EN => "Turn whole detection buckets on or off",
         FR => "Activer ou désactiver des groupes entiers de détection",
@@ -1119,6 +1149,12 @@ lang_strings! {
         FR => "Revenir au menu principal",
         IT => "Torna al menu principale",
         ES => "Volver al menú principal",
+    }
+    help_dm_image_scan {
+        EN => "Redact secrets in clipboard screenshots (needs tesseract)",
+        FR => "Expurger les secrets des captures du presse-papiers (requiert tesseract)",
+        IT => "Oscura i segreti negli screenshot degli appunti (richiede tesseract)",
+        ES => "Redacta secretos en capturas del portapapeles (requiere tesseract)",
     }
     dm_presets {
         EN => "Presets",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod ai_tui;
 pub mod config;
 pub mod detector;
+pub mod image_scan;
 pub mod lang;
 pub mod redact_cli;
 pub mod shell_rc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,19 @@ fn run_trigger() -> anyhow::Result<()> {
         None => return Ok(()),
     };
 
+    // A clipboard image never goes through the text path below: reading it as text
+    // yields raw bytes that the detector can mistake for secrets, which would
+    // overwrite the screenshot. When an image is present we own the outcome here -
+    // redact it if the feature is on, otherwise leave it untouched.
+    if let Some((width, height, bytes)) = monitor.read_image() {
+        if config.enable_image_scan {
+            run_image_redaction(&mut monitor, &detector, &config, width, height, bytes)?;
+        } else {
+            eprintln!("{}", config.lang.cli_nothing_to_redact());
+        }
+        return Ok(());
+    }
+
     // Source order: prefer the PRIMARY selection (highlighted text). Most Linux apps
     // populate it automatically when the user selects text with the mouse, so no Ctrl+C
     // is needed. If PRIMARY is empty (some Electron apps skip it, or the user is on a
@@ -301,6 +314,65 @@ fn run_trigger() -> anyhow::Result<()> {
         notify::drop_fallback_notification(config.notification_timeout_secs, config.lang);
     } else if !config.silent {
         notify::redacted_notification(total, config.notification_timeout_secs, config.lang);
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_image_redaction(
+    _monitor: &mut clipboard::ClipboardMonitor,
+    _detector: &Detector,
+    _config: &Config,
+    _width: usize,
+    _height: usize,
+    _bytes: Vec<u8>,
+) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_image_redaction(
+    monitor: &mut clipboard::ClipboardMonitor,
+    detector: &Detector,
+    config: &Config,
+    width: usize,
+    height: usize,
+    bytes: Vec<u8>,
+) -> anyhow::Result<()> {
+    use secret_stripper::image_scan::{self, ImageResult, TesseractOcr};
+
+    match image_scan::redact_image(&bytes, width as u32, height as u32, &TesseractOcr, detector) {
+        ImageResult::Unavailable => {
+            eprintln!("{}", config.lang.cli_image_scan_failed());
+        }
+        ImageResult::NoSecrets => {
+            eprintln!("{}", config.lang.cli_no_secrets());
+        }
+        ImageResult::DetectedUnmappable => {
+            eprintln!("{}", config.lang.cli_image_detected_unmappable());
+        }
+        ImageResult::Redacted { bytes, w, h, count } => {
+            if let Err(e) = monitor.replace_image(w as usize, h as usize, bytes) {
+                log::error!("clipboard image write failed: {}", e);
+                notify::write_failed_notification(
+                    config.notification_timeout_secs,
+                    config.lang,
+                    false,
+                );
+                eprintln!(
+                    "{}",
+                    config
+                        .lang
+                        .cli_clipboard_write_failed(false, &e.to_string())
+                );
+                return Ok(());
+            }
+            stats::append(count as u64);
+            eprintln!("{}", config.lang.cli_redacted(count));
+            if !config.silent {
+                notify::redacted_notification(count, config.notification_timeout_secs, config.lang);
+            }
+        }
     }
     Ok(())
 }

--- a/src/tui/menu.rs
+++ b/src/tui/menu.rs
@@ -19,6 +19,8 @@ enum MenuItem {
     Language,
     DetectionSettings,
     RedactStyle,
+    #[cfg(target_os = "linux")]
+    ImageScan,
     ManageInstallation,
     Exit,
     StarOnGitHub,
@@ -31,62 +33,78 @@ pub fn show_menu(config: &mut Config) -> anyhow::Result<Option<MenuAction>> {
     let mut selected = 0usize;
     let mut flash: Option<String> = None;
 
-    let items: [MenuItem; 8] = [
+    let mut items: Vec<MenuItem> = vec![
         MenuItem::ToggleNotifications,
         MenuItem::RebindHotkey,
         MenuItem::Language,
         MenuItem::DetectionSettings,
         MenuItem::RedactStyle,
-        MenuItem::ManageInstallation,
-        MenuItem::Exit,
-        MenuItem::StarOnGitHub,
     ];
-    // Indices that begin a new visual group (blank line before).
-    let group_starts = [6usize, 7];
+    #[cfg(target_os = "linux")]
+    items.push(MenuItem::ImageScan);
+    items.push(MenuItem::ManageInstallation);
+    items.push(MenuItem::Exit);
+    items.push(MenuItem::StarOnGitHub);
+
+    // Blank line before the Exit group and before Star, wherever they land.
+    let exit_idx = items
+        .iter()
+        .position(|i| matches!(i, MenuItem::Exit))
+        .unwrap_or(items.len() - 2);
+    let group_starts = [exit_idx, exit_idx + 1];
 
     let result = loop {
-        let rows = [
-            MenuRow {
-                icon: "\u{1F514}",
-                label: config.lang.lbl_menu_notifications().to_string(),
-                icon_color: theme::icon_yellow(),
-            },
-            MenuRow {
-                icon: "\u{1F3B9}",
-                label: config.lang.lbl_rebind_hotkey(&config.hotkey),
-                icon_color: theme::icon_blue(),
-            },
-            MenuRow {
-                icon: "\u{1F310}",
-                label: config.lang.lbl_menu_language(config.lang.endonym()),
-                icon_color: theme::icon_green(),
-            },
-            MenuRow {
-                icon: "\u{2699}\u{FE0F}",
-                label: config.lang.lbl_detection_settings().to_string(),
-                icon_color: theme::icon_green(),
-            },
-            MenuRow {
-                icon: "\u{270F}\u{FE0F}",
-                label: config.lang.dm_redact_style().to_string(),
-                icon_color: theme::icon_yellow(),
-            },
-            MenuRow {
-                icon: "\u{1F9F0}",
-                label: config.lang.lbl_manage_installation().to_string(),
-                icon_color: theme::icon_magenta(),
-            },
-            MenuRow {
-                icon: "\u{1F6AA}",
-                label: config.lang.lbl_exit().to_string(),
-                icon_color: theme::icon_blue(),
-            },
-            MenuRow {
-                icon: "\u{2B50}",
-                label: config.lang.lbl_star_github().to_string(),
-                icon_color: theme::icon_yellow(),
-            },
-        ];
+        let rows: Vec<MenuRow> = items
+            .iter()
+            .map(|item| match item {
+                MenuItem::ToggleNotifications => MenuRow {
+                    icon: "\u{1F514}",
+                    label: config.lang.lbl_menu_notifications().to_string(),
+                    icon_color: theme::icon_yellow(),
+                },
+                MenuItem::RebindHotkey => MenuRow {
+                    icon: "\u{1F3B9}",
+                    label: config.lang.lbl_rebind_hotkey(&config.hotkey),
+                    icon_color: theme::icon_blue(),
+                },
+                MenuItem::Language => MenuRow {
+                    icon: "\u{1F310}",
+                    label: config.lang.lbl_menu_language(config.lang.endonym()),
+                    icon_color: theme::icon_green(),
+                },
+                MenuItem::DetectionSettings => MenuRow {
+                    icon: "\u{2699}\u{FE0F}",
+                    label: config.lang.lbl_detection_settings().to_string(),
+                    icon_color: theme::icon_green(),
+                },
+                MenuItem::RedactStyle => MenuRow {
+                    icon: "\u{270F}\u{FE0F}",
+                    label: config.lang.dm_redact_style().to_string(),
+                    icon_color: theme::icon_yellow(),
+                },
+                #[cfg(target_os = "linux")]
+                MenuItem::ImageScan => MenuRow {
+                    icon: "\u{1F5BC}\u{FE0F}",
+                    label: config.lang.dm_image_scan(config.enable_image_scan),
+                    icon_color: theme::icon_green(),
+                },
+                MenuItem::ManageInstallation => MenuRow {
+                    icon: "\u{1F9F0}",
+                    label: config.lang.lbl_manage_installation().to_string(),
+                    icon_color: theme::icon_magenta(),
+                },
+                MenuItem::Exit => MenuRow {
+                    icon: "\u{1F6AA}",
+                    label: config.lang.lbl_exit().to_string(),
+                    icon_color: theme::icon_blue(),
+                },
+                MenuItem::StarOnGitHub => MenuRow {
+                    icon: "\u{2B50}",
+                    label: config.lang.lbl_star_github().to_string(),
+                    icon_color: theme::icon_yellow(),
+                },
+            })
+            .collect();
 
         let footer = if let Some(msg) = &flash {
             msg.clone()
@@ -97,6 +115,8 @@ pub fn show_menu(config: &mut Config) -> anyhow::Result<Option<MenuAction>> {
                 MenuItem::Language => config.lang.help_language().to_string(),
                 MenuItem::DetectionSettings => config.lang.help_detection_settings().to_string(),
                 MenuItem::RedactStyle => config.lang.help_dm_redact_style().to_string(),
+                #[cfg(target_os = "linux")]
+                MenuItem::ImageScan => config.lang.help_dm_image_scan().to_string(),
                 MenuItem::ManageInstallation => config.lang.help_manage_installation().to_string(),
                 MenuItem::Exit => config.lang.help_exit().to_string(),
                 MenuItem::StarOnGitHub => config.lang.help_star_github().to_string(),
@@ -150,6 +170,12 @@ pub fn show_menu(config: &mut Config) -> anyhow::Result<Option<MenuAction>> {
                         let _ = crate::tui::redact_style::show(&mut terminal, config);
                         terminal.clear()?;
                         let _ = crate::tui::drain_pending_events();
+                        continue;
+                    }
+                    #[cfg(target_os = "linux")]
+                    MenuItem::ImageScan => {
+                        config.enable_image_scan = !config.enable_image_scan;
+                        config.save()?;
                         continue;
                     }
                     MenuItem::ManageInstallation => {


### PR DESCRIPTION
## Summary

Adds clipboard screenshot redaction. When the hotkey is pressed and the clipboard holds an image, the image is OCR'd with tesseract, run through the same detector as text, and the words containing secrets are blacked out before the image is written back. Off by default, Linux only (X11 and Wayland).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (alters existing behavior or output)
- [ ] Refactor / internal change (no behavior change)
- [ ] Documentation, tooling, or CI

## Related issues

None.

## Changes

- New `image_scan` module: tesseract OCR, span-to-box mapping, black-box paint.
- `run_trigger` handles a clipboard image first; falls through to text when none.
- `enable_image_scan` config flag (default off) with a Linux-only menu toggle.
- Detection reuses the existing engine; only the secret words are redacted.

## Testing

- [x] `just ci` is green locally (format, lint, tests)
- [x] Added or updated tests for this change
- [x] Manually verified the behavior end-to-end

Verified on:

- [x] Linux
- [ ] macOS
- [ ] Windows